### PR TITLE
Change image extraction logic

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -309,14 +309,19 @@ public class ArticleTextExtractor {
             }
 
             if (extractImages) {
-                List<ImageResult> images = new ArrayList<ImageResult>();
-                Element imgEl = determineImageSource(bestMatchElement, images);
-                if (imgEl != null) {
-                    res.setImageUrl(SHelper.replaceSpaces(imgEl.attr("src")));
-                    // TODO remove parent container of image if it is contained in bestMatchElement
-                    // to avoid image subtitles flooding in
+                final String metadataImageUrl = extractImageUrl(doc);
+                if (metadataImageUrl.isEmpty()) {
+                    final List<ImageResult> images = new ArrayList<ImageResult>();
+                    final Element imgEl = determineImageSource(bestMatchElement, images);
+                    if (imgEl != null) {
+                        res.setImageUrl(SHelper.replaceSpaces(imgEl.attr("src")));
+                        // TODO remove parent container of image if it is contained in bestMatchElement
+                        // to avoid image subtitles flooding in
 
-                    res.setImages(images);
+                        res.setImages(images);
+                    }
+                } else {
+                    res.setImageUrl(metadataImageUrl);
                 }
             }
 
@@ -335,24 +340,16 @@ public class ArticleTextExtractor {
             }
 
             // extract links from the same best element
-            String fullhtml = bestMatchElement.toString();
-            Elements children = bestMatchElement.select("a[href]"); // a with href = link
-            String linkstr = "";
-            Integer linkpos = 0;
+            final String fullhtml = bestMatchElement.toString();
+            final Elements children = bestMatchElement.select("a[href]"); // a with href = link
             Integer lastlinkpos = 0;
             for (Element child : children) {
-                linkstr = child.toString();
-                linkpos = fullhtml.indexOf(linkstr, lastlinkpos);
+                final String linkstr = child.toString();
+                final int linkpos = fullhtml.indexOf(linkstr, lastlinkpos);
                 res.addLink(child.attr("abs:href"), child.text(), linkpos);
                 lastlinkpos = linkpos;
             }
             res.setTextList(formatter.getTextList(bestMatchElement));
-        }
-
-        if (extractImages) {
-            if (res.getImageUrl().isEmpty()) {
-                res.setImageUrl(extractImageUrl(doc));
-            }
         }
 
         res.setRssUrl(extractRssUrl(doc));
@@ -768,8 +765,7 @@ public class ArticleTextExtractor {
     }
 
     /**
-     * Tries to extract an image url from metadata if determineImageSource
-     * failed
+     * Tries to extract an image url from metadata
      *
      * @return image url or empty str
      */
@@ -1170,10 +1166,9 @@ public class ArticleTextExtractor {
             if (title.length() > 35)
                 weight += 20;
 
-            String rel = null;
             boolean noFollow = false;
             if (e.parent() != null) {
-                rel = e.parent().attr("rel");
+                final String rel = e.parent().attr("rel");
                 if (rel != null && rel.contains("nofollow")) {
                     noFollow = rel.contains("nofollow");
                     weight -= 40;
@@ -1187,7 +1182,7 @@ public class ArticleTextExtractor {
                 score = score / 2;
             }
 
-            ImageResult image = new ImageResult(sourceUrl, weight, title, height, width, alt, noFollow);
+            final ImageResult image = new ImageResult(sourceUrl, weight, title, height, width, alt, noFollow);
             images.add(image);
         }
 

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -73,7 +73,7 @@ public class ArticleTextExtractorTest {
         // http://edition.cnn.com/2011/WORLD/africa/04/06/libya.war/index.html?on.cnn=1
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("cnn.html")));
         assertEquals("Gadhafi asks Obama to end NATO bombing", res.getTitle());
-        assertEquals("/2011/WORLD/africa/04/06/libya.war/t1larg.libyarebel.gi.jpg", res.getImageUrl());
+        assertEquals("http://i.cdn.turner.com/cnn/2011/WORLD/africa/04/06/libya.war/tzvids.libyarebel.gi.jpg", res.getImageUrl());
         assertTrue("cnn:" + res.getText(), res.getText().startsWith("Tripoli, Libya (CNN) -- As rebel and pro-government forces in Libya maneuvered on the battlefield Wedn"));
         assertEquals("By the CNN Wire Staff", res.getAuthorName());
     }
@@ -83,7 +83,7 @@ public class ArticleTextExtractorTest {
         // http://www.bbc.co.uk/news/world-latin-america-21226565
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("bbc_noscript.html")));
         assertEquals("Brazil mourns nightclub fire dead", res.getTitle());
-        assertEquals("http://news.bbcimg.co.uk/media/images/65545000/gif/_65545798_brazil_santa_m_kiss_464.gif", res.getImageUrl());
+        assertEquals("http://news.bbcimg.co.uk/media/images/65551000/jpg/_65551014_65549948.jpg", res.getImageUrl());
         assertTrue(res.getText().startsWith("Brazil has declared three days of national mourning for 231 people killed in a nightclub fire in the southern city of Santa Maria."));
         assertEquals("Caio Quero", res.getAuthorName());
     }
@@ -93,7 +93,7 @@ public class ArticleTextExtractorTest {
         // http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("reuters.html")));
         assertEquals("Knight trading loss shows cracks in equity markets", res.getTitle());
-        assertEquals("http://s1.reutersmedia.net/resources/r/?m=02&d=20120803&t=2&i=637797752&w=460&fh=&fw=&ll=&pl=&r=CBRE872074Y00", res.getImageUrl());
+        assertEquals("http://s1.reutersmedia.net/resources/r/?m=02&d=20120803&t=2&i=637797752&w=130&fh=&fw=&ll=&pl=&r=CBRE872074Y00", res.getImageUrl());
         assertTrue("reuters:" + res.getText(), res.getText().startsWith("(Reuters) - The software glitch that cost Knight Capital Group $440 million in just 45 minutes reveals the deep fault lines in stock markets that are increasingly dominated by sophisticated high-speed trading systems. But Wall Street firms and regulators have few easy solutions for such problems."));
         assertEquals("Jed Horowitz and Joseph Menn", res.getAuthorName());
     }
@@ -103,7 +103,7 @@ public class ArticleTextExtractorTest {
         // http://www.bbc.co.uk/news/magazine-21206964
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("bbc_nocss.html")));
         assertEquals("Digital artists inspired by the GIF's resurgence", res.getTitle());
-        assertEquals("http://news.bbcimg.co.uk/media/images/65563000/jpg/_65563005_65562996.jpg", res.getImageUrl());
+        assertEquals("http://news.bbcimg.co.uk/media/images/65563000/jpg/_65563632_gifpromo.jpg", res.getImageUrl());
         assertTrue("bbc no css:" + res.getText(), res.getText().startsWith("They were created in the late-1980s, but recent years have seen a resurgence in popularity of GIF animated files."));
     }
 
@@ -129,7 +129,7 @@ public class ArticleTextExtractorTest {
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("golem.html")));
         assertThat(res.getText(), is(notNullValue()));
         assertThat(res.getText(), startsWith("Unter dem Namen \"Aurora\" hat Firefox einen neuen Kanal mit Vorabversionen von Firefox eingerichtet."));
-        assertEquals("http://scr3.golem.de/screenshots/1104/Firefox-Aurora/thumb480/aurora-nighly-beta-logos.png", res.getImageUrl());
+        assertEquals("http://www.golem.de/1104/82797-9183-i.png", res.getImageUrl());
         assertThat(res.getTitle(), equalTo("Mozilla: Vorabversionen von Firefox 5 und 6 veröffentlicht - Golem.de"));
     }
 
@@ -147,7 +147,7 @@ public class ArticleTextExtractorTest {
         // http://www.faz.net/s/Rub469C43057F8C437CACC2DE9ED41B7950/Doc~EBA775DE7201E46E0B0C5AD9619BD56E9~ATpl~Ecommon~Scontent.html
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("faz.html")));
         assertTrue(res.getText(), res.getText().startsWith("Deutschland hat vor, ganz auf Atomkraft zu verzichten. Ist das eine gute"));
-        assertEquals("/m/{5F104CCF-3B5A-4B4C-B83E-4774ECB29889}g225_4.jpg", res.getImageUrl());
+        assertEquals("/m/{5F104CCF-3B5A-4B4C-B83E-4774ECB29889}q225_4.jpg", res.getImageUrl());
         assertEquals("FAZ Electronic Media", res.getAuthorName());
         assertEquals(Arrays.asList("Atomkraft", "Deutschland", "Jahren", "Atommüll", "Fukushima", "Problem", "Brand", "Kohle", "2011", "11",
                 "Stewart", "Atomdebatte", "Jahre", "Boden", "Treibhausgase", "April", "Welt", "Müll", "Radioaktivität",
@@ -249,7 +249,7 @@ public class ArticleTextExtractorTest {
     public void testTechcrunch() throws Exception {
         // http://techcrunch.com/2011/04/04/twitter-advanced-search/
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("techcrunch.html")));
-        assertEquals("http://tctechcrunch2011.files.wordpress.com/2011/04/screen-shot-2011-04-04-at-12-11-36-pm.png?w=285&h=85", res.getImageUrl());
+        assertEquals("http://i1.wp.com/tctechcrunch2011.files.wordpress.com/2011/04/screen-shot-2011-04-04-at-12-11-36-pm.png?resize=680%2C680", res.getImageUrl());
         assertEquals("Twitter Finally Brings Advanced Search Out Of Purgatory; Updates Discovery Algorithms", res.getTitle());
         assertTrue(res.getText(), res.getText().startsWith("A couple weeks ago, we wrote a post wishing Twitter a happy fifth birthday, but also noting "));
         assertEquals("MG Siegler", res.getAuthorName());
@@ -307,7 +307,7 @@ public class ArticleTextExtractorTest {
         // http://blog.talawah.net/2011/04/gavin-king-unviels-red-hats-top-secret.html
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("blogger.html")));
         assertTrue(res.getText(), res.getText().startsWith("Gavin King of Red Hat/Hibernate/Seam fame recently"));
-        assertEquals("http://3.bp.blogspot.com/-cyMzveP3IvQ/TaR7f3qkYmI/AAAAAAAAAIk/mrChE-G0b5c/s200/Java.png", res.getImageUrl());
+        assertEquals("http://3.bp.blogspot.com/-cyMzveP3IvQ/TaR7f3qkYmI/AAAAAAAAAIk/mrChE-G0b5c/s72-c/Java.png", res.getImageUrl());
         assertEquals("The Brain Dump: Gavin King unveils Red Hat's Java killer successor: The Ceylon Project", res.getTitle());
         assertEquals("http://blog.talawah.net/feeds/posts/default?alt=rss", res.getRssUrl());
         assertEquals("Marc Richards", res.getAuthorName());
@@ -317,7 +317,7 @@ public class ArticleTextExtractorTest {
     public void testNyt() throws Exception {
         // http://dealbook.nytimes.com/2011/04/11/for-defense-in-galleon-trial-no-time-to-rest/
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("nyt.html")));
-        assertEquals("http://graphics8.nytimes.com/images/2011/04/12/business/dbpix-raj-rajaratnam-1302571800091/dbpix-raj-rajaratnam-1302571800091-tmagSF.jpg",
+        assertEquals("http://graphics8.nytimes.com/images/blogs_v5/../icons/t_logo_291_black.png",
                 res.getImageUrl());
         assertTrue(res.getText(), res.getText().startsWith("I wouldn’t want to be Raj Rajaratnam’s lawyer right now."));
         assertEquals("Andrew Ross Sorkin", res.getAuthorName());
@@ -349,7 +349,7 @@ public class ArticleTextExtractorTest {
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("cnn2.html")));
         assertEquals("Democrats to use Social Security against GOP this fall - CNN.com", article.getTitle());
         assertTrue(article.getText(), article.getText().startsWith("Washington (CNN) -- Democrats pledged "));
-        assertEquals(article.getImageUrl(), "http://i.cdn.turner.com/cnn/2010/POLITICS/08/13/democrats.social.security/story.kaine.gi.jpg");
+        assertEquals(article.getImageUrl(), "http://i.cdn.turner.com/cnn/2010/POLITICS/08/13/democrats.social.security/tzvids.kaine.gi.jpg");
         assertEquals("Ed Hornick", article.getAuthorName());
     }
     
@@ -376,7 +376,7 @@ public class ArticleTextExtractorTest {
         // http://www.foxnews.com/politics/2010/08/14/russias-nuclear-help-iran-stirs-questions-improved-relations/
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("foxnews.html")));
         assertTrue("Foxnews:" + article.getText(), article.getText().startsWith("Apr. 8: President Obama signs the New START treaty with Russian President Dmitry Medvedev at the Prague Castle. Russia's announcement "));
-        assertEquals("http://a57.foxnews.com/static/managed/img/Politics/397/224/startsign.jpg", article.getImageUrl());
+        assertEquals("http://a57.foxnews.com/static/managed/img/Politics/60/60/startsign.jpg", article.getImageUrl());
         assertEquals("", article.getAuthorName());
     }
 
@@ -406,7 +406,7 @@ public class ArticleTextExtractorTest {
         // http://online.wsj.com/article/SB10001424052748704532204575397061414483040.html
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("wsj.html")));
         assertTrue(article.getText(), article.getText().startsWith("The Obama administration has paid out less than a third of the nearly $230 billion"));
-        assertEquals("http://si.wsj.net/public/resources/images/OB-JO747_stimul_D_20100814113803.jpg", article.getImageUrl());
+        assertEquals("http://s.wsj.net/public/resources/images/OB-JO759_0814st_A_20100814143158.jpg", article.getImageUrl());
         assertEquals("LOUISE RADNOFSKY", article.getAuthorName());
     }
 
@@ -432,7 +432,7 @@ public class ArticleTextExtractorTest {
         // http://sports.espn.go.com/espn/commentary/news/story?id=5461430
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("espn.html")));
         assertTrue(article.getText(), article.getText().startsWith("If you believe what college football coaches have said about sports"));
-        assertEquals("http://a.espncdn.com/photo/2010/0813/ncf_i_mpouncey1_300.jpg", article.getImageUrl());
+        assertEquals("http://a.espncdn.com/photo/2010/0813/pg2_g_bush3x_300.jpg", article.getImageUrl());
     }
 
     @Test
@@ -468,7 +468,7 @@ public class ArticleTextExtractorTest {
         //String url = "http://gigaom.com/apple/apples-next-macbook-an-800-mac-for-the-masses/";
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("gigaom.html")));
         assertTrue(article.getText(), article.getText().startsWith("The MacBook Air is a bold move forward "));
-        assertEquals("http://gigapple.files.wordpress.com/2010/10/macbook-feature.png?w=300&h=200", article.getImageUrl());
+        assertEquals("http://gigapple.files.wordpress.com/2010/10/macbook-feature.png?w=604", article.getImageUrl());
     }
 
     @Test
@@ -515,7 +515,7 @@ public class ArticleTextExtractorTest {
         //String url = "http://www.thedailybeast.com/blogs-and-stories/2010-11-01/ted-sorensen-speechwriter-behind-jfks-best-jokes/?cid=topic:featured1";
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("thedailybeast.html")));
         assertTrue(article.getText(), article.getText().startsWith("Legendary Kennedy speechwriter Ted Sorensen passed"));
-        assertEquals("http://www.tdbimg.com/files/2010/11/01/img-article---katz-ted-sorensen_163531624950.jpg",
+        assertEquals("http://www.tdbimg.com/resizeimage/YTo0OntzOjM6ImltZyI7czo2MToiMjAxMC8xMS8wMS9pbWctYnMtYm90dG9tLS0ta2F0ei10ZWQtc29yZW5zZW5fMTYzMjI4NjEwMzUxLmpwZyI7czo1OiJ3aWR0aCI7aTo1MDtzOjY6ImhlaWdodCI7aTo1MDtzOjY6InJhbmRvbSI7czoxOiIxIjt9.jpg",
                 article.getImageUrl());
     }
 
@@ -662,7 +662,7 @@ public class ArticleTextExtractorTest {
         //String url = "http://news.cnet.com/8301-30686_3-20014053-266.html?tag=topStories1";
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("cnet.html")));
         assertTrue(article.getText(), article.getText().startsWith("NEW YORK--Verizon Communications is prepping a new"));
-        assertEquals("http://i.i.com.com/cnwk.1d/i/tim//2010/08/18/Verizon_iPad_and_live_TV_610x458.JPG", article.getImageUrl());
+        assertEquals("http://i.i.com.com/cnwk.1d/i/tim//2010/08/18/Verizon_iPad_and_live_TV_with_big_TV_60x60.JPG", article.getImageUrl());
     }
 
     @Test
@@ -679,7 +679,7 @@ public class ArticleTextExtractorTest {
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("thefrisky.html")));
         assertTrue(article.getText(), article.getText().startsWith("Rachel Dratch had been keeping the identity of her baby daddy "));
 
-        assertEquals("http://cdn.thefrisky.com/images/uploads/rachel_dratch_102810_m.jpg",
+        assertEquals("http://cdn.thefrisky.com/images/uploads/rachel_dratch_102810_t.jpg",
               article.getImageUrl());
         assertEquals("Rachel Dratch Met Her Baby Daddy At A Bar", article.getTitle());
     }
@@ -757,7 +757,8 @@ public class ArticleTextExtractorTest {
     @Test
     public void testImagesList() throws Exception {
         // http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803
-        JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("reuters.html")));
+        // manually tweaked to remove og:image and image_src tags
+        JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("reuters_list.html")));
         assertEquals(1, res.getImagesCount());
         assertEquals(res.getImageUrl(), res.getImages().get(0).src);
         assertEquals("http://s1.reutersmedia.net/resources/r/?m=02&d=20120803&t=2&i=637797752&w=460&fh=&fw=&ll=&pl=&r=CBRE872074Y00",

--- a/src/test/resources/de/jetwick/snacktory/reuters_list.html
+++ b/src/test/resources/de/jetwick/snacktory/reuters_list.html
@@ -1,0 +1,1546 @@
+<!--[if !IE]> This has been served from cache <![endif]-->
+<!--[if !IE]> Request served from apache server: S264630NJ2XSF25 <![endif]-->
+<!--[if !IE]> Cached on Fri, 03 Aug 2012 09:13:36 GMT and will expire on Fri, 03 Aug 2012 09:28:32 GMT <![endif]-->
+<!--[if !IE]> token: bb281714-d1bb-4a7a-9384-9be75663a3cd <![endif]-->
+<!--[if !IE]> Prepopulated from the cache-server <![endif]-->
+<!--[if !IE]> App Server /S264630NJ2XSF57/ <![endif]-->
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<script type="text/javascript" src="http://static.reuters.com/resources/media/global/trc/bootstrap20120706.js"></script>
+
+<title>
+      Knight trading loss shows cracks in equity markets
+| Reuters
+
+</title>
+		<meta name="DCSext.ChannelList" content="topNews;newsOne;businessNews;gc05;FundsandETFs;ford;Nissan;Inspiration;creditMarkets;everything;treasuryMarkets;Schwab;MercedesBenz;Shell;Amtrak;Davos;Topnews1;yahoo2Dub;yahoo3;Sprintboard;Pfizer;echoActivityStream;ANZ;Suntrust_SmallBiz;AllianzInvestments;HSBC_US;FedExSMB;Hyundai;MSDynamics;Goldman;everythingButHugin;SprintNow;OutloudFeed;chsenergy;chsfood;HPEnterprise;JPMorgan;CFA;jpGambaroPeople;analysis;sprintxpert2;samsung;newsproHome;audib2b;Pfizersafe;cfaglobal;merrilledge;ernstyoung;Xerox;shipping;citianniversary;dassaultuk;airline;PrudentialInvestments;VanessaTest;lyxor;greenpeace;MLGZero;fedex_neg;GCA-NewsPro">
+
+
+<META name="description" content="(Reuters) - The software glitch that cost Knight Capital Group $440 million in just 45 minutes reveals the deep fault lines in stock markets that are increasingly dominated by sophisticated high-speed">
+	  <META name="keywords" content="United States, BERNARD DONEFER, Brendan Mcdermid, Larry Tabb, Matt Andresen, Maureen O&#039;Hara, Roy Niederhoffer">
+<META name="REVISION_DATE" content="Fri Aug 03 09:10:32 UTC 2012">
+
+<META name="DCSext.Comments" content="1">
+<META property="og:title" content="Knight trading loss shows cracks in equity markets" />
+<META property="og:type" content="article" />
+<META property="og:site_name" content="Reuters" />
+<META property="og:url" content="http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803" />
+<META property="fb:app_id" content="169549326390879"/>
+		<link rel="canonical" href="http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803" />
+		  	<link rel="shortcut icon" href="http://s3.reutersmedia.net/resources_v2/images/favicon.ico" />
+  <link rel="icon" href="http://s3.reutersmedia.net/resources_v2/images/favicon.ico" />
+
+	<link href="http://s3.reutersmedia.net/resources_v2/css/rcom-main.css" rel="stylesheet" />
+<script src="http://s3.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/yahoo/yahoo-min.js" type="text/javascript"></script>
+	<script src="http://s4.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/event/event-min.js" type="text/javascript"></script>
+	<script src="http://s3.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/dom/dom-min.js" type="text/javascript"></script>
+	<script src="http://s4.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/yahoo-dom-event/yahoo-dom-event.js" type="text/javascript"></script>
+	<script src="http://s3.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/animation/animation-min.js" type="text/javascript"></script>
+	<script src="http://s3.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/connection/connection-min.js" type="text/javascript"></script>
+	<script src="http://s2.reutersmedia.net/resources_v2/js/libraries/yui_2_7_0/cookie/cookie-min.js" type="text/javascript"></script>
+<script src="http://s3.reutersmedia.net/resources_v2/js/libraries/jquery-1.6.1.min.js" type="text/javascript"></script>
+<script src="http://s3.reutersmedia.net/resources_v2/js/rcom-main.js"></script>
+	<script src="http://s4.reutersmedia.net/resources_v2/js/rcom-agent.js"></script>
+	<script src="http://s4.reutersmedia.net/resources_v2/js/extensions.js"></script>
+	<script src="http://s4.reutersmedia.net/resources_v2/js/rcom-ads.js"></script>
+	<script src="http://s4.reutersmedia.net/resources_v2/js/rcom-wt-mlt.js"></script>
+	<script src="http://s2.reutersmedia.net/resources_v2/js/rcom-pid.js"></script>
+	<script src="http://s3.reutersmedia.net/resources_v2/js/rcom-geoIP.js"></script>
+<script type="text/javascript" src="/assets/rcom-cobrand.js"></script>
+
+<script type="text/javascript" src="http://s4.reutersmedia.net/resources_v2/js/rcom-tns.js"></script>
+<link href="/resources_v2/css/rcom-article.css?view=20111129" rel="stylesheet" />
+<link href="/resources_v2/css/rcom-network-footer.css?view=20111129" rel="stylesheet" />
+<link href="/resources_v2/css/rcom-comments.css?view=20101129" rel="stylesheet" />
+<script type="text/javascript" src="/resources_v2/js/rcom-article.js"></script>
+<script type="text/javascript" src="/resources_v2/js/rcom-linkback.js"></script>
+
+<!--Slideshow JS and CSS files --> 
+
+<script type="text/javascript" src="/resources_v2/js/YUI_slideshow.js"></script>
+<link href="/resources_v2/css/rcom-slideshow.css" type="text/css" rel="stylesheet" />
+<link href="/resources_v2/css/rcom-multimedia.css" type="text/css" rel="stylesheet" />
+
+<style type="text/css">
+.articleComments .grid8 .dividerInlineH { margin-top: 10px; }
+#relatedInteractive h2 { font-size: 14px; margin: 5px 0; }
+#bankrate .section{margin-bottom: 18px;}
+</style>
+
+<!--Press release disclaimer --> 
+
+<style >
+.pressRelease{
+ color:#666;
+ font-size:11px;
+ margin-bottom:10px;
+}
+.required{
+  color:red;
+  font-size:11px;
+  font-weight:bold;
+} 
+</style>
+
+
+
+</head>
+<body>
+
+<script>
+var revop_wtfpc = YAHOO.util.Cookie.get("WT_FPC"); // read webtrends cookie
+if (revop_wtfpc==null) {
+	var u = ";U=NC;";
+	}
+else
+	{
+	var u = ";U="+revop_wtfpc+";";
+	}
+</script> <!-- see if snrd cookie was set by trigger page -->
+<script>
+var srnd = YAHOO.util.Cookie.get("srnd_keyword");
+var srnd_sequence = YAHOO.util.Cookie.get("srnd_sequence");
+if (srnd!=null && srnd!="")
+  {
+         var srnd="srnd="+srnd+";srnd_sequence="+srnd_sequence+";";
+  }
+
+</script>
+
+
+<link href="http://s4.reutersmedia.net/resources_v2/css/rcom-masthead-nav.css" rel="stylesheet" />
+<script src="/assets/info" type="text/javascript"></script>
+<script type="text/javascript">
+var currentUsedEdition = 'BETAUS';
+</script>
+
+<div id="header">
+<a name="top" id="top" style="position: absolute;overflow:hidden;">&nbsp;</a>
+	<div id="marketsHeader"></div>
+	<div id="masthead">
+		<div class="mast-strip">
+		<div id="logo"><a id="logoLink" href="/"><img src="/resources_v2/images/masthead-logo.gif" alt="Reuters" border="0" /></a></div>
+
+	<div id="editionsTop" class="panel editions">
+			<ul id="editionSwitchTop" class="editionSwitch">
+				<li>
+					<div class="currentEditionTitle">Edition:</div>
+					<div class="currentEdition">U.S.</div>
+					<div class="editionArrow"></div>
+					<ul>
+						<li><a href="http://af.reuters.com">Africa</a></li>
+						<li><a href="http://ara.reuters.com">Arabic</a></li>
+						<li><a href="http://ar.reuters.com">Argentina</a></li>
+						<li><a href="http://br.reuters.com">Brazil</a></li>
+						<li><a href="http://ca.reuters.com">Canada</a></li>
+						<li><a href="http://cn.reuters.com">China</a></li>
+						<li><a href="http://fr.reuters.com">France</a></li>
+						<li><a href="http://de.reuters.com">Germany</a></li>
+<li><a href="http://in.reuters.com">India</a></li>
+<li><a href="http://it.reuters.com">Italy</a></li>
+						<li><a href="http://jp.reuters.com">Japan</a></li>
+						<li><a href="http://lta.reuters.com">Latin America</a></li>
+						<li><a href="http://mx.reuters.com">Mexico</a></li>
+				    <li><a href="http://ru.reuters.com">Russia</a></li>
+						<li><a href="http://es.reuters.com">Spain</a></li>
+<li><a href="http://uk.reuters.com">United Kingdom</a></li>
+</ul>
+				</li>
+			</ul>
+		</div>
+		<div id="search" class="panel">
+		<div id="searchbox">
+			<form id="searchForm" name="searchbox" method="get" action="/search" autocomplete="off">
+				<input id="searchfield" name="blob" type="text" value="Search News & Quotes" size="30"
+					onfocus="var strSearchValue = document.forms['searchbox'].blob.value;if(strSearchValue.trim() == 'Search News & Quotes'){document.forms['searchbox'].blob.value = '';}"
+					onblur="var strSearchValue = document.forms['searchbox'].blob.value;if(strSearchValue.trim() == ''){document.forms['searchbox'].blob.value = 'Search News & Quotes';}"
+					onkeypress="if(event.keyCode == 13) {document.forms['searchbox'].submit();return false;}" maxlength="128"
+				/>
+				<input type="submit" id="searchbuttonNav" onclick="return Reuters.utils.submitSearch();" value="">
+			</form>
+		</div>
+	</div>
+		<div id="utilities" class="panel"></div>
+	</div>
+	</div>
+
+	<div id="dd-navigation">
+    	<div id="nav-strip">
+            <ul>
+                <li class="nav-item no-subnav" id="nav-item_1"><a href="/home" ><span class="primary-link">Home</span></a>
+                    </li>
+                <li class="nav-item" id="nav-item_2"><a href="/finance" ><span class="primary-link">Business</span></a>
+                    <div class="subnav double" id="subnav_2">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/finance" target="_top">Business Home</a></li>
+                            <li class=""><a href="/finance/economy" target="_top">Economy</a></li>
+                            <li class=""><a href="/news/technology" target="_top">Technology</a></li>
+                            <li class=""><a href="/news/media" target="_top">Media</a></li>
+                            <li class=""><a href="/finance/smallBusiness" target="_top">Small Business</a></li>
+                            <li class="lastChild "><a href="http://newsandinsight.thomsonreuters.com/Legal/" target="_top">Legal</a></li>
+                            </ul><ul class="two"><li class=""><a href="/finance/deals" target="_top">Deals</a></li>
+                            <li class=""><a href="/finance/markets/earnings" target="_top">Earnings</a></li>
+                            <li class=""><a href="/social" target="_top">Social Pulse</a></li>
+                            <li class=""><a href="/news/video?videoChannel=5" target="_top">Business Video</a></li>
+                            <li class=""><a href="/news/video/reuters-tv/the-freeland-file" target="_top">The Freeland File</a></li>
+                            <li class="lastChild "><a href="/subjects/aerospace-and-defense" target="_top">Aerospace & Defense</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_3"><a href="/finance/markets" ><span class="primary-link">Markets</span></a>
+                    <div class="subnav double" id="subnav_3">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/finance/markets" target="_top">Markets Home</a></li>
+                            <li class=""><a href="/finance/markets/us" target="_top">U.S. Markets</a></li>
+                            <li class=""><a href="/finance/markets/europe" target="_top">European Markets</a></li>
+                            <li class=""><a href="/finance/markets/asia" target="_top">Asian Markets</a></li>
+                            <li class=""><a href="/finance/global-market-data" target="_top">Global Market Data</a></li>
+                            <li class=""><a href="/finance/markets/indices" target="_top">Indices</a></li>
+                            <li class="lastChild "><a href="/finance/deals/mergers" target="_top">M&A</a></li>
+                            </ul><ul class="two"><li class=""><a href="/finance/stocks" target="_top">Stocks</a></li>
+                            <li class=""><a href="/finance/bonds" target="_top">Bonds</a></li>
+                            <li class=""><a href="/finance/currencies" target="_top">Currencies</a></li>
+                            <li class=""><a href="/finance/commodities" target="_top">Commodities</a></li>
+                            <li class=""><a href="/finance/futures" target="_top">Futures</a></li>
+                            <li class=""><a href="/finance/funds" target="_top">Funds</a></li>
+                            <li class="lastChild "><a href="http://www.pehub.com/" target="_top">peHUB</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_4"><a href="/news/world" ><span class="primary-link">World</span></a>
+                    <div class="subnav double" id="subnav_4">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/news/world" target="_top">World Home</a></li>
+                            <li class=""><a href="/news/us" target="_top">U.S.</a></li>
+                            <li class=""><a href="/places/brazil" target="_top">Brazil</a></li>
+                            <li class=""><a href="/places/china" target="_top">China</a></li>
+                            <li class=""><a href="/subjects/euro-zone" target="_top">Euro Zone</a></li>
+                            <li class="lastChild "><a href="/places/japan" target="_top">Japan</a></li>
+                            </ul><ul class="two"><li class=""><a href="/places/mexico" target="_top">Mexico</a></li>
+                            <li class=""><a href="/places/russia" target="_top">Russia</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/india" target="_top">India Insight</a></li>
+                            <li class=""><a href="/news/video?videoChannel=117760" target="_top">World Video</a></li>
+                            <li class=""><a href="/news/video/reuters-tv/reuters-investigates" target="_top">Reuters Investigates</a></li>
+                            <li class="lastChild "><a href="/news/video/reuters-tv/decoder" target="_top">Decoder</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_5"><a href="/politics" ><span class="primary-link">Politics</span></a>
+                    <div class="subnav " id="subnav_5">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/politics" target="_top">Politics Home</a></li>
+                            <li class=""><a href="/politics/elections-2012" target="_top">Election 2012</a></li>
+                            <li class=""><a href="/politics/american-mosaic" target="_top">Campaign Polling</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/frontrow/" target="_top">Tales from the Trail</a></li>
+                            <li class=""><a href="/politics/political-punchlines" target="_top">Political Punchlines</a></li>
+                            <li class=""><a href="/subjects/supreme-court" target="_top">Supreme Court</a></li>
+                            <li class="lastChild "><a href="/news/video?videoChannel=1003" target="_top">Politics Video</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_6"><a href="/news/technology" ><span class="primary-link">Tech</span></a>
+                    <div class="subnav " id="subnav_6">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/news/technology" target="_top">Technology Home</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/mediafile" target="_top">MediaFile</a></li>
+                            <li class=""><a href="/news/science" target="_top">Science</a></li>
+                            <li class=""><a href="/news/video?videoChannel=6" target="_top">Tech Video</a></li>
+                            <li class=""><a href="/news/video/reuters-tv/tech-tonic" target="_top">Tech Tonic</a></li>
+                            <li class="lastChild "><a href="/social" target="_top">Social Pulse</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_7"><a href="http://blogs.reuters.com/us" ><span class="primary-link">Opinion</span></a>
+                    <div class="subnav double" id="subnav_7">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="http://blogs.reuters.com/us" target="_top">Opinion Home</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/chrystia-freeland/" target="_top">Chrystia Freeland</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/john-lloyd" target="_top">John Lloyd</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/felix-salmon" target="_top">Felix Salmon</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/jackshafer" target="_top">Jack Shafer</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/david-rohde" target="_top">David Rohde</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/bernddebusmann" target="_top">Bernd Debusmann</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/nader-mousavizadeh/" target="_top">Nader Mousavizadeh</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/lucy-marcus/" target="_top">Lucy P. Marcus</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/david-cay-johnston/ " target="_top">David Cay Johnston</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/bethany-mclean/" target="_top">Bethany McLean</a></li>
+                            <li class="lastChild "><a href="http://blogs.reuters.com/anatole-kaletsky" target="_top">Anatole Kaletsky</a></li>
+                            </ul><ul class="two"><li class=""><a href="http://blogs.reuters.com/edward-hadas/" target="_top">Edward Hadas</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/hugo-dixon/" target="_top">Hugo Dixon</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/ian-bremmer/" target="_top">Ian Bremmer</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/lawrencesummers/" target="_top">Lawrence Summers</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/susanglasser/" target="_top">Susan Glasser</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/great-debate" target="_top">The Great Debate</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/stories-id-like-to-see/" target="_top">Steven Brill</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/jack-and-suzy-welch" target="_top">Jack & Suzy Welch</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/thinking-global/" target="_top">Frederick Kempe</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/christopher-papagianis/" target="_top">Christopher Papagianis</a></li>
+                            <li class="lastChild "><a href="http://blogs.reuters.com/mark-leonard" target="_top">Mark Leonard</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_8"><a href="http://blogs.reuters.com/breakingviews/" ><span class="primary-link">Breakingviews</span></a>
+                    <div class="subnav " id="subnav_8">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="http://blogs.reuters.com/breakingviews/category/equities/" target="_top">Equities</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/breakingviews/category/credit" target="_top">Credit</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/breakingviews/category/private-equity/" target="_top">Private Equity</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/breakingviews/category/m-a/" target="_top">M&A</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/breakingviews/category/macro-markets/" target="_top">Macro & Markets</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/breakingviews/category/politics/" target="_top">Politics</a></li>
+                            <li class="lastChild "><a href="/news/video/reuters-tv/breakingviews" target="_top">Breakingviews Video</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_9"><a href="/finance/personal-finance" ><span class="primary-link">Money</span></a>
+                    <div class="subnav double" id="subnav_9">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/finance/personal-finance" target="_top">Money Home</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/taxbreak/" target="_top">Tax Break</a></li>
+                            <li class=""><a href="/subjects/2012-lipper-best-mutual-fund-awards" target="_top">Lipper Awards 2012</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/globalinvesting" target="_top">Global Investing</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/muniland" target="_top">MuniLand</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/unstructuredfinance/" target="_top">Unstructured Finance</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/linda-stern/ " target="_top">Linda Stern</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/mark-miller/" target="_top">Mark Miller</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/john-wasik/" target="_top">John Wasik</a></li>
+                            <li class="lastChild "><a href="http://blogs.reuters.com/jim-saft/" target="_top">James Saft</a></li>
+                            </ul><ul class="two"><li class=""><a href="https://commerce.us.reuters.com/purchase/default.do" target="_top">Analyst Research</a></li>
+                            <li class=""><a href="http://alerts.us.reuters.com/US/company.asp" target="_top">Alerts</a></li>
+                            <li class=""><a href="http://portfolio.us.reuters.com/US/watchlist/create.asp" target="_top">Watchlist</a></li>
+                            <li class=""><a href="http://portfolio.us.reuters.com/US/public/index.asp" target="_top">Portfolio</a></li>
+                            <li class=""><a href="http://stockscreener.us.reuters.com/Stock/US/Index?quickscreen=gaarp" target="_top">Stock Screener</a></li>
+                            <li class=""><a href="http://funds.us.reuters.com/US/screener/screener.asp" target="_top">Fund Screener</a></li>
+                            <li class=""><a href="/news/video?videoChannel=303" target="_top">Personal Finance Video</a></li>
+                            <li class=""><a href="/news/video/reuters-tv/money-clip" target="_top">Money Clip</a></li>
+                            <li class="lastChild "><a href="/news/video/reuters-tv/investing-201" target="_top">Investing 201</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_10"><a href="/news/lifestyle" ><span class="primary-link">Life</span></a>
+                    <div class="subnav " id="subnav_10">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="http://www.reuters.com/london-olympics-2012" target="_top">Olympics</a></li>
+                            <li class=""><a href="/news/health" target="_top">Health</a></li>
+                            <li class=""><a href="/news/sports" target="_top">Sports</a></li>
+                            <li class=""><a href="/news/entertainment/arts" target="_top">Arts</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/faithworld" target="_top">Faithworld</a></li>
+                            <li class=""><a href="/finance/business-travel" target="_top">Business Traveler</a></li>
+                            <li class=""><a href="/news/entertainment" target="_top">Entertainment</a></li>
+                            <li class=""><a href="/news/oddlyEnough" target="_top">Oddly Enough</a></li>
+                            <li class="lastChild "><a href="/news/video?videoChannel=1004" target="_top">Lifestyle Video</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_11"><a href="/news/pictures" ><span class="primary-link">Pictures</span></a>
+                    <div class="subnav " id="subnav_11">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/news/pictures" target="_top">Pictures Home</a></li>
+                            <li class=""><a href="http://blogs.reuters.com/photo" target="_top">Reuters Photographers</a></li>
+                            <li class="lastChild "><a href="http://blogs.reuters.com/fullfocus" target="_top">Full Focus</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                <li class="nav-item" id="nav-item_12"><a href="/news/video/reuters-tv" ><span class="primary-link">Video</span></a>
+                    <div class="subnav " id="subnav_12">
+                       
+                        <div class="subnav-inner">
+                        <ul class="one">
+                       
+                            <li class=""><a href="/news/video/reuters-tv" target="_top">Reuters TV</a></li>
+                            <li class="lastChild "><a href="/news/video" target="_top">Reuters News</a></li>
+                            </ul>
+                      
+                       </div>
+                       
+                       </div>
+
+                       </li>
+                </ul>
+       	</div>
+    </div>
+</div>
+<script src="http://s2.reutersmedia.net/resources_v2/js/libraries/jquery.bgiframe.js" type="text/javascript"></script>
+<script src="http://s4.reutersmedia.net/resources_v2/js/rcom-nav.js" type="text/javascript"></script>
+
+<div id="content"><div class="section bleeding" id="breakingNewsBand">
+	<div class="sectionContent">
+<script type="text/javascript">
+Reuters.namespace("info");
+Reuters.info.articleId = 'USBRE87203X20120803';
+Reuters.info.articlePartnerURI = '';
+Reuters.info.channel = 'businessNews';
+Reuters.info.articleUrl = '/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803';
+</script>
+
+<div class="columnCenter">
+
+</div><!--
+		  SHARED MODULE ID: "347501" hidden for channel: true
+		    channel: businessNews
+		    include chans: [technologyNews, lifestyleMolt], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<div id="breakingNewsContent"></div>
+<script type="text/javascript">
+Reuters.utils.replaceContent("breakingNewsContent", "/assets/breakingNews", null, null);
+</script>
+
+</div>
+
+</div>
+
+</div>
+</div>
+<div class="section bleeding" id="bannerStrip">
+	<div class="sectionContent">
+<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<script language="javascript" type="text/javascript">
+// Grapeshot Constructor
+document.write('<scri' + 'pt language="javascript" type="text/javascript" src="http://reuters.gscontxt.net/Main/channels.cgi?url=' + window.location.href + '"></scri' + 'pt>');
+</script><div class="ad">
+
+		<script language="javascript" type="text/javascript">
+			// krux kseg and kuid from krux header tag
+			//var kruxvars = (typeof(kseg)=='undefined'?'':kseg) + (typeof(kuid)=='undefined'?'':kuid);	  
+		  var u = (typeof(u)=='undefined'?'':u);
+		  var n_pbtvars = (typeof(n_pbt)=='undefined'?'':n_pbt);
+		  var srndvars = (typeof(srnd)=='undefined'?'':srnd);
+		  var gscvars = (typeof(gs_channels)=='undefined' ? '' : gs_channels);
+		  var adsrc = 'us.reuters/bizfinance/businessnews/article;' + 'type=leaderboard;sz=728x90;tile=1;vbc=lyxor;articleID=USBRE87203X20120803;ord=' + (typeof(tmstmp)!='undefined'?tmstmp:12345) + '' + u + n_pbtvars + srndvars + gscvars + (typeof(seg)=='undefined'?'':seg) + '?';
+		  if ( typeof(AD_TRACKER) != 'undefined' ) {
+		  adsrc = AD_TRACKER.processAdSrcType(adsrc);
+		  } 
+
+		  
+		  if ((typeof (hideAllAds) == 'undefined' || hideAllAds == false) && (typeof (AD_TRACKER) == 'undefined' || AD_TRACKER.isAdHidden('leaderboard') == false) &&
+		      (typeof (hideAd_10036157) == 'undefined' || hideAd_10036157 == false)) {
+		        document.write('<scri' + 'pt language="javascript" type="text/javascript" src="http://ad.doubleclick.net/adj/' + adsrc + '"></scri' + 'pt>');
+		  }
+
+		  </script>
+
+		<noscript>
+		    <a href="http://ad.doubleclick.net/jump/us.reuters/bizfinance/businessnews/article;type=leaderboard;sz=728x90;tile=1;vbc=lyxor;articleID=USBRE87203X20120803;ord=3245?" target="_blank">
+		      <img src="http://ad.doubleclick.net/ad/us.reuters/bizfinance/businessnews/article;type=leaderboard;sz=728x90;tile=1;vbc=lyxor;articleID=USBRE87203X20120803;ord=3245?" width="728" height="90" border="0" alt="">
+		    </a>
+		</noscript>
+
+		</div>
+
+		</div>
+
+</div>
+
+</div>
+</div>
+<div class="section bleeding" id="articleTabSection">
+	<div class="sectionContent">
+<div id="freqCap_pushdown" style="display:none;">
+	<div id="pushdownContainer" class="pushdownContainer">
+    	<div class="ad">
+
+		<script language="javascript" type="text/javascript">
+			// krux kseg and kuid from krux header tag
+			//var kruxvars = (typeof(kseg)=='undefined'?'':kseg) + (typeof(kuid)=='undefined'?'':kuid);	  
+		  var u = (typeof(u)=='undefined'?'':u);
+		  var n_pbtvars = (typeof(n_pbt)=='undefined'?'':n_pbt);
+		  var srndvars = (typeof(srnd)=='undefined'?'':srnd);
+		  var gscvars = (typeof(gs_channels)=='undefined' ? '' : gs_channels);
+		  var adsrc = 'us.reuters/bizfinance/businessnews/article;' + 'type=pushdown;sz=1x1;articleID=USBRE87203X20120803;taga=aaaaaaaaa;ord=' + (typeof(tmstmp)!='undefined'?tmstmp:12345) + '' + u + n_pbtvars + srndvars + gscvars + (typeof(seg)=='undefined'?'':seg) + '?';
+		  if ( typeof(AD_TRACKER) != 'undefined' ) {
+		  adsrc = AD_TRACKER.processAdSrcType(adsrc);
+		  } 
+
+		  
+		  if ( typeof(freqCap_pushdown) == 'undefined' || freqCap_pushdown == null ) {
+		      try { console.debug("frequency manager: %s is undefined, could be channel include/exclude or scheduling", 'freqCap_pushdown') } catch(e) {};
+		  }
+		  if ( typeof(freqCap_pushdown) != 'undefined' &&
+		       ((typeof(freqCap_pushdown.isAdNeeded) != 'undefined' && freqCap_pushdown.isAdNeeded()) ||
+		        (typeof(freqCap_pushdown.isDefaultAdNeeded) != 'undefined' && freqCap_pushdown.isDefaultAdNeeded()))) {
+		  
+		  if ((typeof (hideAllAds) == 'undefined' || hideAllAds == false) && (typeof (AD_TRACKER) == 'undefined' || AD_TRACKER.isAdHidden('pushdown') == false) &&
+		      (typeof (hideAd_10032916) == 'undefined' || hideAd_10032916 == false)) {
+		        document.write('<scri' + 'pt language="javascript" type="text/javascript" src="http://ad.doubleclick.net/adj/' + adsrc + '"></scri' + 'pt>');
+		  }
+
+		  
+		  }
+		  </script>
+
+		<noscript>
+		    <a href="http://ad.doubleclick.net/jump/us.reuters/bizfinance/businessnews/article;type=pushdown;sz=1x1;articleID=USBRE87203X20120803;taga=aaaaaaaaa;ord=0086?" target="_blank">
+		      <img src="http://ad.doubleclick.net/ad/us.reuters/bizfinance/businessnews/article;type=pushdown;sz=1x1;articleID=USBRE87203X20120803;taga=aaaaaaaaa;ord=0086?" width="1" height="1" border="0" alt="">
+		    </a>
+		</noscript>
+
+		</div>
+
+		</div>
+</div>
+
+<script type="text/javascript">
+	if ( typeof(freqCap_pushdown) != 'undefined' && 
+       ((typeof(freqCap_pushdown.isAdNeeded) != 'undefined' && (freqCap_pushdown.isAdNeeded())) || 
+       (typeof(freqCap_pushdown.isDefaultAdNeeded) != 'undefined' && freqCap_pushdown.isDefaultAdNeeded()))) {
+	    document.getElementById('freqCap_pushdown').style.display = 'block';
+	}
+</script>
+
+
+<div class="linebreak"></div>
+	<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<script type="text/javascript" src="http://s3.reutersmedia.net/resources_v2/js/commentLogin.js"></script>
+<div class="tabs">
+	<ul>
+		<li class="current" tns="no" ><a href="/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803">Article</a></li>
+    <li tns="no" ><a href="/article/comments/idUSBRE87203X20120803">Comments&nbsp;(2)</a></li>
+</ul>
+</div>
+
+</div>
+
+</div>
+
+</div>
+</div>
+<div class="section gridlined4" id="articleContent">
+	<div class="sectionContent">
+<div id="freqCap_poe" style="display:none;">
+	<div id="poeContainer" class="poeContainer">
+    	<div class="ad">
+
+		<script language="javascript" type="text/javascript">
+			// krux kseg and kuid from krux header tag
+			//var kruxvars = (typeof(kseg)=='undefined'?'':kseg) + (typeof(kuid)=='undefined'?'':kuid);	  
+		  var u = (typeof(u)=='undefined'?'':u);
+		  var n_pbtvars = (typeof(n_pbt)=='undefined'?'':n_pbt);
+		  var srndvars = (typeof(srnd)=='undefined'?'':srnd);
+		  var gscvars = (typeof(gs_channels)=='undefined' ? '' : gs_channels);
+		  var adsrc = 'us.reuters/bizfinance/businessnews/article;' + 'type=poe;sz=1x1;articleID=USBRE87203X20120803;taga=aaaaaaaaa;ord=' + (typeof(tmstmp)!='undefined'?tmstmp:12345) + '' + u + n_pbtvars + srndvars + gscvars + (typeof(seg)=='undefined'?'':seg) + '?';
+		  if ( typeof(AD_TRACKER) != 'undefined' ) {
+		  adsrc = AD_TRACKER.processAdSrcType(adsrc);
+		  } 
+
+		  
+		  if ( typeof(freqCap_poe) == 'undefined' || freqCap_poe == null ) {
+		      try { console.debug("frequency manager: %s is undefined, could be channel include/exclude or scheduling", 'freqCap_poe') } catch(e) {};
+		  }
+		  if ( typeof(freqCap_poe) != 'undefined' &&
+		       ((typeof(freqCap_poe.isAdNeeded) != 'undefined' && freqCap_poe.isAdNeeded()) ||
+		        (typeof(freqCap_poe.isDefaultAdNeeded) != 'undefined' && freqCap_poe.isDefaultAdNeeded()))) {
+		  
+		  if ((typeof (hideAllAds) == 'undefined' || hideAllAds == false) && (typeof (AD_TRACKER) == 'undefined' || AD_TRACKER.isAdHidden('poe') == false) &&
+		      (typeof (hideAd_10034971) == 'undefined' || hideAd_10034971 == false)) {
+		        document.write('<scri' + 'pt language="javascript" type="text/javascript" src="http://ad.doubleclick.net/adj/' + adsrc + '"></scri' + 'pt>');
+		  }
+
+		  
+		  }
+		  </script>
+
+		<noscript>
+		    <a href="http://ad.doubleclick.net/jump/us.reuters/bizfinance/businessnews/article;type=poe;sz=1x1;articleID=USBRE87203X20120803;taga=aaaaaaaaa;ord=9799?" target="_blank">
+		      <img src="http://ad.doubleclick.net/ad/us.reuters/bizfinance/businessnews/article;type=poe;sz=1x1;articleID=USBRE87203X20120803;taga=aaaaaaaaa;ord=9799?" width="1" height="1" border="0" alt="">
+		    </a>
+		</noscript>
+
+		</div>
+
+		</div>
+</div>
+
+<script type="text/javascript">
+	if ( typeof(freqCap_poe) != 'undefined' && 
+       ((typeof(freqCap_poe.isAdNeeded) != 'undefined' && (freqCap_poe.isAdNeeded())) || 
+       (typeof(freqCap_poe.isDefaultAdNeeded) != 'undefined' && freqCap_poe.isDefaultAdNeeded()))) {
+	    document.getElementById('freqCap_poe').style.display = 'block';
+	}
+</script>
+
+
+<div class="linebreak"></div>
+	<div class="sectionColumns">
+
+<div class="column1 gridPanel grid4">
+<div class="ad">
+
+		<script language="javascript" type="text/javascript">
+			// krux kseg and kuid from krux header tag
+			//var kruxvars = (typeof(kseg)=='undefined'?'':kseg) + (typeof(kuid)=='undefined'?'':kuid);	  
+		  var u = (typeof(u)=='undefined'?'':u);
+		  var n_pbtvars = (typeof(n_pbt)=='undefined'?'':n_pbt);
+		  var srndvars = (typeof(srnd)=='undefined'?'':srnd);
+		  var gscvars = (typeof(gs_channels)=='undefined' ? '' : gs_channels);
+		  var adsrc = 'us.reuters/bizfinance/businessnews/article;' + 'type=mpu;sz=300x250;tile=2;vbc=lyxor;articleID=USBRE87203X20120803;ord=' + (typeof(tmstmp)!='undefined'?tmstmp:12345) + '' + u + n_pbtvars + srndvars + gscvars + (typeof(seg)=='undefined'?'':seg) + '?';
+		  if ( typeof(AD_TRACKER) != 'undefined' ) {
+		  adsrc = AD_TRACKER.processAdSrcType(adsrc);
+		  } 
+
+		  
+		  if ((typeof (hideAllAds) == 'undefined' || hideAllAds == false) && (typeof (AD_TRACKER) == 'undefined' || AD_TRACKER.isAdHidden('mpu') == false) &&
+		      (typeof (hideAd_10036163) == 'undefined' || hideAd_10036163 == false)) {
+		        document.write('<scri' + 'pt language="javascript" type="text/javascript" src="http://ad.doubleclick.net/adj/' + adsrc + '"></scri' + 'pt>');
+		  }
+
+		  </script>
+
+		<noscript>
+		    <a href="http://ad.doubleclick.net/jump/us.reuters/bizfinance/businessnews/article;type=mpu;sz=300x250;tile=2;vbc=lyxor;articleID=USBRE87203X20120803;ord=2442?" target="_blank">
+		      <img src="http://ad.doubleclick.net/ad/us.reuters/bizfinance/businessnews/article;type=mpu;sz=300x250;tile=2;vbc=lyxor;articleID=USBRE87203X20120803;ord=2442?" width="300" height="250" border="0" alt="">
+		    </a>
+		</noscript>
+
+		</div>
+
+		<div id="articlePackage"><div class="assetBuddy" name="Counterparties ACMS 7-31">
+                        <span name="trackingEnabledModule" moduleName="E0803121748_297010"><script language="javascript">addImpression("E0803121748_297010");</script><div class="module"><div class="moduleHeader"><h3><a target="_blank" href="http://counterparties.com/">Counterparties: Today's Best Links</a></h3></div><div class="moduleBody"><div class="feature"><div class="photo"><a target="_blank" href="http://counterparties.com/"><img src="http://s3.reutersmedia.net/resources/media/global/assets/images/20120802/20120802_26918720120802165539.jpg" alt="Prescription drug bottles are seen in New York, October 27, 2011. REUTERS/Shannon Stapleton" title="Prescription drug bottles are seen in New York, October 27, 2011. REUTERS/Shannon Stapleton" border="0" /></a></div><h2><a target="_blank" href="http://counterparties.com/">Prescription drugs' newest ingredient: gamification</a></h2><p>A San Francisco start-up has developed an app that turns taking prescriptions into a game. Users can earns discounts and rewards for following doctor's orders. &nbsp; <span class="inlineLinks"><a target="_blank" href="http://counterparties.com/">Learn&nbsp;More</a></span>&nbsp;</p></div><ul><li><a target="_blank" href="http://www.propublica.org/thetrade/item/why-do-we-keep-swooning-over-failed-bankers">Sandy Weill is back in the news. But &quot;what's a guy gotta do around here to lose a little credibility?&quot;</a></li><li><a target="_blank" href="http://online.wsj.com/article/SB10000872396390443687504577563673018004342.html">Google Wallet to become more like a real wallet and allow multiple cards</a></li><li><a href="https://commerce.us.reuters.com/profile/pages/newsletter/begin.do">Sign up for the Counterparties email!</a></li></ul></div></div></span></div>
+                </div><div class="linebreak"></div>
+	<script type="text/javascript" src="/resources_v2/js/libraries/highlighter-0.6_sm.js"></script> 
+<div id="searchInterceptResults">
+<div id="searchModule"></div>
+</div>
+<script type='text/javascript'>
+highlighter.highlight();
+Reuters.utils.addLoadEvent(function() { Reuters.utils.replaceContent('searchModule', '/assets/searchIntercept?blob='+highlighter.searchKeywords(), null, null) });
+</script>
+<style type="text/css">
+#searchInterceptResults {display:none;}
+#searchInterceptResults.wResults {display: block;}
+</style>
+
+<!--[if !IE]>Start Most Social<![endif]--><div id="social-links">	<h3>Follow Reuters</h3>		<ul>		<li class="facebook"><a href="http://www.facebook.com/pages/Reuters/114050161948682"><span class="icon"></span>Facebook</a></li>		<li class="twitter"><a href="http://www.twitter.com/reuters"><span class="icon"></span>Twitter</a></li>		<li class="rss"><a href="http://www.reuters.com/tools/rss"><span class="icon"></span>RSS</a></li>		<li class="youtube last"><a href="http://www.youtube.com/reuters"><span class="icon"></span>YouTube</a></li>		</ul>		<div class="linebreak"></div></div><div class="linebreak"></div>
+	<div id="bankrate"><div class="section">
+	<div class="sectionContent">
+<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<script type="text/javascript">
+	Reuters.namespace("info");
+	Reuters.info.outbrain_env = 'produsx';
+</script>
+<script type="text/javascript">
+document.write('<div class="OUTBRAIN" data-src="http://www.reuters.com' + Reuters.info.articleUrl + '?env' + Reuters.info.outbrain_env +'=0" data-widget-id="AR_4" data-ob-template="reuters" ></div>');
+</script>
+<script type="text/javascript" async="async" src="http://widgets.outbrain.com/outbrain.js"></script><div class="linebreak"></div>
+	</div>
+
+</div>
+
+</div>
+</div>
+
+
+</div><div id="bankrate"><!--
+		  SHARED MODULE ID: "433888" hidden for channel: true
+		    channel: businessNews
+		    include chans: [marketsNews, globalMarketsNews, hotStocksNews, ousivMolt], empty: false
+		    exclude chans: , empty: true
+		-->
+		</div><div id="bankrate"><!--
+		  SHARED MODULE ID: "433892" hidden for channel: true
+		    channel: businessNews
+		    include chans: [PersonalFinance, Retirement], empty: false
+		    exclude chans: , empty: true
+		-->
+		</div><div id="most-popular"><div class="most-popular-header"></div><div class="linebreak"></div>
+	<div id="mostPopularRead"><div class="module">
+		
+		<div class="moduleHeader">
+				<h3>
+					Read</h3>
+			</div>
+		<div class="moduleBody">
+		<ol>
+		<li><a href="/article/2012/08/02/us-usa-securtity-nuclear-idUSBRE8711LG20120802"  >U.S. nuclear bomb facility shut after security breach</a>
+<div class="relatedHeadlineInfo">
+	<span class="timestamp">02 Aug 2012</span> </div>
+	</li><li><a href="/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803"  >Knight trading loss shows cracks in equity markets</a>
+<div class="relatedHeadlineInfo">
+	<span class="timestamp">5:10am EDT</span> </div>
+	</li><li><a href="/article/2012/08/02/us-usa-mold-iowa-idUSBRE8711TF20120802"  >Iowa governor moves out of mansion because of black mold</a>
+<div class="relatedHeadlineInfo">
+	<span class="timestamp">02 Aug 2012</span> </div>
+	</li><li><a href="/article/2012/08/03/us-samsung-note-idUSBRE87203P20120803"  >Samsung to unveil new Galaxy Note in late August</a>
+<div class="relatedHeadlineInfo">
+	<span class="timestamp">02 Aug 2012</span> </div>
+	</li><li><a href="/article/2012/08/02/us-sharp-apple-shipments-idUSBRE8710GF20120802"  >Sharp to start shipping iPhone screens to Apple this month</a>
+<div class="relatedHeadlineInfo">
+	<span class="timestamp">02 Aug 2012</span> </div>
+	</li></ol>
+	</div>
+		</div>
+		</div><div id="mostPopularDiscussed"><div class="module">
+		
+		<div class="moduleHeader">
+				<h3>
+					Discussed</h3>
+			</div>
+		<div class="moduleBody">
+		<ul>
+		<li class="dup"><div class="commentcount"><a href="http://blogs.reuters.com/article-comments/2012/08/01/exclusive-obama-authorizes-secret-u-s-support-for-syrian-rebels/#comments">219</a></div>
+			<a href="http://www.reuters.com/article/idUSBRE8701OK20120801"  >Exclusive: Obama authorizes secret U.S. support for Syrian rebels</a>
+</li><li class="dup"><div class="commentcount"><a href="http://blogs.reuters.com/article-comments/2012/08/01/union-leader-strives-to-ease-obamas-white-guy-problem/#comments">157</a></div>
+			<a href="http://www.reuters.com/article/idUSBRE8701JT20120801"  >Union leader strives to ease Obama&#8217;s &#8221;white guy problem&#8221;</a>
+</li><li class="dup"><div class="commentcount"><a href="http://blogs.reuters.com/article-comments/2012/07/29/romney-backs-israel-if-needs-to-strike-iran-aide-says/#comments">109</a></div>
+			<a href="http://www.reuters.com/article/idUSBRE86Q1DO20120729"  >Romney backs Israel if needs to strike Iran: aide says</a>
+</li></ul>
+	</div>
+		</div>
+		</div><script>
+stripPR = function(modId) {
+	if (document.getElementById(modId)) {
+		var lis = document.getElementById(modId).getElementsByTagName("li");
+		var delindex = 0;
+		for (i=0; i<lis.length; i++) {
+			if (lis[i].innerHTML.search("PR Newswire") != -1) {	
+				lis[i].setAttribute("id", "pressli" + delindex);
+				delindex++;
+			}
+		}
+		for (i=0; i<delindex; i++) {
+			document.getElementById("pressli" + i).parentNode.removeChild(document.getElementById("pressli" + i));
+		}
+	}
+}
+stripPR("mostPopularRead");
+stripPR("mostPopularShared");
+</script><div class="linebreak"></div>
+	
+
+</div><style type="text/css">
+#marchex{float:left;}
+#marchex .module{margin: 0 0 8px 0;}
+#marchex .module .moduleHeader{border: none;margin: 6px 0 0 6px;}
+#marchex .module .moduleHeader h3{color: #000000;font-size: 12px;margin: 0;}
+</style>
+
+<div id="marchex">
+<div class="module">
+<div class="moduleHeader"><h3>Sponsored Links</h3></div>
+<div class="moduleBody"><script type="text/javascript" src="http://jlinks.industrybrains.com/jsct?sid=851&amp;ct=REUTERS_BUSINESS_INVESTING&amp;tr=LEFTRAIL_BUSINESSINVESTING&amp;num=3&amp;layt=300x250&amp;fmt=simp"></script><div class="linebreak"></div>
+	
+
+<!--
+		  SHARED MODULE ID: "439185" hidden for channel: true
+		    channel: businessNews
+		    include chans: [PersonalFinance, fundsFundsNews, environmentNews, globalMarketsNews, energySector, bondsNews, hedgeFundsNews, hotStocksNews, ventureDealsBeatNews, privateEquity], empty: false
+		    exclude chans: , empty: true
+		-->
+		<!--
+		  SHARED MODULE ID: "439187" hidden for channel: true
+		    channel: businessNews
+		    include chans: [healthNews, innovationNews, lifestyleMolt, oddlyEnoughNews, entertainmentNews, businessTravel, sportsNews], empty: false
+		    exclude chans: , empty: true
+		-->
+		<!--
+		  SHARED MODULE ID: "439189" hidden for channel: true
+		    channel: businessNews
+		    include chans: [technologyNews], empty: false
+		    exclude chans: , empty: true
+		-->
+		</div>
+</div>
+</div>
+
+
+
+<div class="most-popular more-in-business"><!--
+		  SHARED MODULE ID: "303464" hidden for channel: true
+		    channel: businessNews
+		    include chans: [innovationNews], empty: false
+		    exclude chans: , empty: true
+		-->
+		</div><!--[if !IE]>End Most Social<![endif]--><!--
+		  SHARED MODULE ID: "410263" hidden for channel: true
+		    channel: businessNews
+		    include chans: [globalMarketsNews, PersonalFinance], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<div id="recommendedNewsletters"><!--
+		  SHARED MODULE ID: "304753" hidden for channel: true
+		    channel: businessNews
+		    include chans: [GCA-Economy2010], empty: false
+		    exclude chans: , empty: true
+		-->
+		</div><div id="mpulow"><div class="ad">
+
+		<script language="javascript" type="text/javascript">
+			// krux kseg and kuid from krux header tag
+			//var kruxvars = (typeof(kseg)=='undefined'?'':kseg) + (typeof(kuid)=='undefined'?'':kuid);	  
+		  var u = (typeof(u)=='undefined'?'':u);
+		  var n_pbtvars = (typeof(n_pbt)=='undefined'?'':n_pbt);
+		  var srndvars = (typeof(srnd)=='undefined'?'':srnd);
+		  var gscvars = (typeof(gs_channels)=='undefined' ? '' : gs_channels);
+		  var adsrc = 'us.reuters/bizfinance/businessnews/article;' + 'type=mpulow;sz=300x250;tile=3;articleID=USBRE87203X20120803;ord=' + (typeof(tmstmp)!='undefined'?tmstmp:12345) + '' + u + n_pbtvars + srndvars + gscvars + (typeof(seg)=='undefined'?'':seg) + '?';
+		  if ( typeof(AD_TRACKER) != 'undefined' ) {
+		  adsrc = AD_TRACKER.processAdSrcType(adsrc);
+		  } 
+
+		  
+		  if ((typeof (hideAllAds) == 'undefined' || hideAllAds == false) && (typeof (AD_TRACKER) == 'undefined' || AD_TRACKER.isAdHidden('mpulow') == false) &&
+		      (typeof (hideAd_13683007) == 'undefined' || hideAd_13683007 == false)) {
+		        document.write('<scri' + 'pt language="javascript" type="text/javascript" src="http://ad.doubleclick.net/adj/' + adsrc + '"></scri' + 'pt>');
+		  }
+
+		  </script>
+
+		<noscript>
+		    <a href="http://ad.doubleclick.net/jump/us.reuters/bizfinance/businessnews/article;type=mpulow;sz=300x250;tile=3;articleID=USBRE87203X20120803;ord=1861?" target="_blank">
+		      <img src="http://ad.doubleclick.net/ad/us.reuters/bizfinance/businessnews/article;type=mpulow;sz=300x250;tile=3;articleID=USBRE87203X20120803;ord=1861?" width="300" height="250" border="0" alt="">
+		    </a>
+		</noscript>
+
+		</div>
+
+		</div><div class="linebreak"></div>
+	<div class="assetBuddy" name="photojournalism_channelcms">
+	<span name="trackingEnabledModule" moduleName="E0803121906_297036"><script language="javascript">addImpression("E0803121906_297036");</script><div class="module"><div class="moduleHeader"><h3><a href="http://www.reuters.com/news/pictures">Pictures</a></h3></div><div class="moduleBody"><div class="feature"><div class="photo"><a href="http://www.reuters.com/news/pictures"><img src="http://s4.reutersmedia.net/resources/media/global/assets/images/20120802/20120802_4385680520120802190038.jpg" alt="Residents ride on a makeshift raft during a heavy downpour along a flooded street in Malabon, Metro Manila August 1, 2012. Typhoon Saola (Gener) is likely to stay in Philippine territory until Friday, the Philippine Atmospheric Geophysical and Astronomical Services Administration (PAGASA) said on Wednesday, and the National Disaster Risk and Reduction Council said the death toll from Gener stood at 12 and one person was reported missing. REUTERS/Erik De Castro (PHILIPPINES - Tags: DISASTER SOCIETY ENVIRONMENT)" title="Residents ride on a makeshift raft during a heavy downpour along a flooded street in Malabon, Metro Manila August 1, 2012. Typhoon Saola (Gener) is likely to stay in Philippine territory until Friday, the Philippine Atmospheric Geophysical and Astronomical Services Administration (PAGASA) said on Wednesday, and the National Disaster Risk and Reduction Council said the death toll from Gener stood at 12 and one person was reported missing. REUTERS/Erik De Castro (PHILIPPINES - Tags: DISASTER SOCIETY ENVIRONMENT)" border="0" /></a></div><h2><a href="http://www.reuters.com/news/pictures">Reuters Photojournalism</a></h2><p>Our day's top images, in-depth photo essays and offbeat slices of life.  See the best of Reuters photography.&nbsp; <span class="inlineLinks"><a href="http://www.reuters.com/news/pictures">See&nbsp;more</a>&nbsp;|&nbsp;<a target="_blank" href="http://reut.rs/N5LShs">Photo&nbsp;caption</a></span>&nbsp;</p></div><div class="dividerInlineH"></div><div class="feature"><div class="photo"><table cellpadding="0" cellspacing="0" border="0"><tr><td valign="middle"><a href="http://www.reuters.com/news/pictures/slideshow?articleId=USRTR35X5G"><div class="slideshowOverlay"></div><img src="http://s1.reutersmedia.net/resources/r/?m=02&d=20120802&t=2&i=637631431&w=120&fh=&fw=&ll=&pl=&r=2012-08-02T185028Z_02_LM2E8821BHWB3_RTRRPP_0_OLY-GYMN-GAWIAA-(GAW024101)" alt="Russia's Victoria Komova performs on the asymmetric bars during the women's individual all-around gymnastics final in the North Greenwich Arena at the London 2012 Olympic Games August 2, 2012. REUTERS/Mike Blake (BRITAIN  - Tags: SPORT OLYMPICS SPORT GYMNASTICS)  " title="Russia's Victoria Komova performs on the asymmetric bars during the women's individual all-around gymnastics final in the North Greenwich Arena at the London 2012 Olympic Games August 2, 2012. REUTERS/Mike Blake (BRITAIN  - Tags: SPORT OLYMPICS SPORT GYMNASTICS)  " border="0" /></a></td></tr></table></div><h2><a href="http://www.reuters.com/news/pictures/slideshow?articleId=USRTR35X5G">London Olympics</a></h2><p>Highlights from day six of the Olympics.&nbsp; <span class="inlineLinks"><a href="http://www.reuters.com/news/pictures/slideshow?articleId=USRTR35X5G">Slideshow</a></span>&nbsp;</p></div><div class="dividerInlineH"></div><div class="feature"><div class="photo"><table cellpadding="0" cellspacing="0" border="0"><tr><td valign="middle"><a href="http://www.reuters.com/news/pictures/slideshow?articleId=USRTR35X98"><div class="slideshowOverlay"></div><img src="http://s3.reutersmedia.net/resources/r/?m=02&d=20120802&t=2&i=637521572&w=120&fh=&fw=&ll=&pl=&r=2012-08-02T141009Z_01_GF2E8820S0D01_RTRRPP_0_OLY-SWIM-CHINA-YESHIWEN-DAY6" alt="Photo" title="Photo" border="0" /></a></td></tr></table></div><h2><a href="http://www.reuters.com/news/pictures/slideshow?articleId=USRTR35X98">China's Olympic school</a></h2><p>The school's slogan, &quot;Today's sports school student, tomorrow's Olympics stars&quot;, greets all who enter the building.&nbsp; <span class="inlineLinks"><a href="http://www.reuters.com/news/pictures/slideshow?articleId=USRTR35X98">Slideshow</a></span>&nbsp;</p></div></div></div></span></div>
+
+	<META name="DCSext.artCMS" content="1">
+<div class="linebreak"></div>
+	</div>
+
+<div class="column2 gridPanel grid8">
+<h1>Knight trading loss shows cracks in equity markets</h1>
+	<div class="facebookRec" tns="no">
+		<iframe src="http://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2012%2F08%2F03%2Fus-knightcapital-trading-technology-idUSBRE87203X20120803&amp;layout=standard&amp;show_faces=false&amp;width=450&amp;action=recommend&amp;colorscheme=light&amp;height=35" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:450px; height:35px;" allowTransparency="true"></iframe>
+        </div>
+<div class="columnRight"><div class="relatedRail gridPanel grid2"><div class="module shareLinks">
+	     <div class="moduleBody">
+	        <ul>
+
+                <li class="twitter " tns="no">
+			<a href="http://twitter.com/share" class="twitter-share-button"  data-counturl="http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803" data-via="reuters" data-text="Knight trading loss shows cracks in equity markets" id="twitter-share-link">Tweet</a>
+              		</li>
+
+                    <script type="text/javascript">
+							var shortUrl = 'http://reut.rs/QyJEN0';
+							var twitterShareLink = document.getElementById("twitter-share-link");
+							twitterShareLink.setAttribute("data-url", shortUrl);
+							Reuters.utils.loadScript("twitterShare", "http://platform.twitter.com/widgets.js");
+						</script>
+					<li class="linkedIn " tns="no">
+                        <script type="text/javascript" src="http://platform.linkedin.com/in.js"></script><script type="in/share" data-url="http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803" data-counter="right"></script>
+                 	</li>
+	            <li class="facebook" tns="no"><span class="hrefClone" onclick="Reuters.utils.popup('http://www.facebook.com/sharer.php?u=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2012%2F08%2F03%2Fus-knightcapital-trading-technology-idUSBRE87203X20120803&t=Knight+trading+loss+shows+cracks+in+equity+markets', 626, 436, 1, 'shareArticle');">Share this</span></li>
+	            <li class="google " tns="no"><span id="googleTag"><g:plusone size="small" count="true" href="http://www.reuters.com/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803"></span></g:plusone></li>
+	<li tns="no" class="email"><span class="hrefClone" onclick="Reuters.utils.popup('/do/emailArticle?articleId=USBRE87203X20120803', 580, 735, 1, 'emailArticle');">Email</span></li>
+			<li tns="no" class="print last"><span class="hrefClone" onclick="Reuters.utils.popup('/assets/print?aid=USBRE87203X20120803', 580, 735, 3, 'printArticle');">Print</span></li>
+			</ul>
+	    </div>
+	</div>
+</div></div><div class="columnRight"><div class="relatedRail gridPanel grid2"></div></div><div class="columnRight"><div class="relatedRail gridPanel grid2"><div id="relatedNews" class="module">
+	<div class="moduleHeader"><h3>Related News</h3></div>
+	<div class="moduleBody">
+		<ul>
+		<li><a href="/article/2012/08/03/us-knightcapital-loss-idUSBRE8710PG20120803">Knight's future in balance after trading disaster</a><div class="timestamp">Thu, Aug 2 2012</div></li><li><a href="/article/2012/08/02/knightcapital-regulators-idUSL2E8J26R720120802">UPDATE 5-Burned by MF Global, futures watchdogs eye Knight</a><div class="timestamp">Thu, Aug 2 2012</div></li><li><a href="/article/2012/08/02/us-facebook-shares-idUSBRE8711AS20120802">Facebook shares dive as deadline for insider sales nears</a><div class="timestamp">Thu, Aug 2 2012</div></li><li><a href="/article/2012/08/02/us-markets-stocks-idUSBRE86M08N20120802">Wall Street takes a hit from ECB disappointment</a><div class="timestamp">Thu, Aug 2 2012</div></li><li><a href="/article/2012/08/02/knightcapital-loss-idUSL2E8J23H520120802">CORRECTED-UPDATE 3-Knight seeks financing after $440 mln loss; shares drop</a><div class="timestamp">Thu, Aug 2 2012</div></li></ul>
+	</div>
+</div>
+</div></div><div class="columnRight"><div class="relatedRail gridPanel grid2"><div id="relatedPosts" class="module">
+	<div class="moduleHeader"><h3>Analysis & Opinion</h3></div>
+	<div class="moduleBody">
+		<ul>
+<li><a href="http://blogs.reuters.com/emily-plucinak/2012/08/02/breakingviews-markets-dark-knight/">Breakingviews: Markets&#8217; dark Knight</a>
+	</li>
+<li><a href="http://blogs.reuters.com/felix-salmon/2012/08/02/counterparties-a-high-frequency-knightmare/">Counterparties: A high-frequency Knightmare</a>
+	</li>
+</ul>
+	</div>
+</div>
+
+</div></div><div class="columnRight"><div class="relatedRail gridPanel grid2"></div></div><div class="columnRight"><div class="relatedRail gridPanel grid2"><div id="thirdPartyLinkbackNews"></div></div></div><div class="columnRight"><div class="relatedRail gridPanel grid2"></div></div><div class="columnRight"><div id="relatedInteractive" class="relatedRail gridPanel grid2"></div></div><div class="columnRight"><div class="relatedRail gridPanel grid2">
+</div></div><script type="text/javascript">
+if(typeof Reuters.info.skipSlideshow == 'undefined'&& document.getElementById("displayFrame")) {Reuters.utils.addLoadEvent(function() { Reuters.utils.loadScript('sJSON','/assets/multimediaJSON?articleId=USBRE87203X20120803&setImage=300&view=100&startNumber=1') });}</script>
+<div class="relatedPhoto landscape" id="articleImage">
+			<img
+        		src="http://s1.reutersmedia.net/resources/r/?m=02&d=20120803&t=2&i=637797752&w=460&fh=&fw=&ll=&pl=&r=CBRE872074Y00"
+        		border="0" alt="A trader stands by the post that trades Knight Capital on the floor of the New York Stock Exchange August 2, 2012. REUTERS/Brendan McDermid"
+        		 />
+     	<div class="rolloverCaption" id="captionContent">
+            	<div class="rolloverBg">
+                    <div class="captionText">
+                        <p>A trader stands by the post that trades Knight Capital on the floor of the New York Stock Exchange August 2, 2012. </p>
+                        <p class="credit">Credit: Reuters/Brendan McDermid</p>
+                    </div>  
+                </div>
+            </div></div>
+	<div id="relatedInlineVideo"><script src="https://www.google.com/jsapi" language="javascript"></script>
+<script language="javascript" src="/resources_v2/js/rcom-tv.js"> </script>
+<script language="javascript" src="/resources_v2/js/widget-videoexpansion.js"> </script></div><span id="articleText">
+<span id="midArticle_start"></span>
+
+<div id="articleInfo">
+        <p class="byline">By Jed Horowitz and Joseph Menn</p>
+        <p>
+        <span class="timestamp">Fri Aug 3, 2012 5:10am EDT</span>
+        </p>
+    </div>
+<span id="midArticle_0"></span><span class="focusParagraph"><p><span class="articleLocatio</span>n">(Reuters) - The software glitch that cost Knight Capital Group $440 million in just 45 minutes reveals the deep fault lines in stock markets that are increasingly dominated by sophisticated high-speed trading systems. But Wall Street firms and regulators have few easy solutions for such problems.</p>
+</span><span id="midArticle_1"></span><p>Automated trading can handle massive volumes of transactions in milliseconds, something human traders could never do. But the benefits come at a cost: stock markets have become a jumble of exchanges, market makers, high-frequency traders, and investors using different systems that can interact in unexpected ways.</p><span id="midArticle_2"></span><p>The May 2010 'Flash Crash', in which U.S. stocks inexplicably sank in a matter of minutes, illustrated how technological problems can cascade. These sorts of problems may be more likely given that many market participants are under pressure to cut costs - including technology spending - as trading margins narrow and regulation costs increase.</p><span id="midArticle_3"></span><p>Since April, a series of embarrassing and costly technology issues have rocked markets and shaken the confidence of investors.</p><span id="midArticle_4"></span><p>BATS Global Markets, an exchange, was unable to complete its own initial public offering because of a technical problem. Nasdaq botched the market debut of Facebook due to technical glitches, costing it tens of millions of dollars, while UBS AG lost more than $350 million in trading Facebook shares and is blaming Nasdaq.</p><span id="midArticle_5"></span><p>"The structure just may be too complicated to work," said Larry Tabb, founder of Tabb Group, a consulting firm that focuses on capital markets.</p><span id="midArticle_6"></span><p>"We may need to think about changing the structure of the market to simplify this," Tabb added.</p><span id="midArticle_7"></span><p>'DARK POOLS'</p><span id="midArticle_8"></span><p>Others argue that regulators can continue to take relatively simple steps, such as creating more finely tuned mechanisms to halt stock trading when trading volumes or prices move too much.</p><span id="midArticle_9"></span><p>Bernard Donefer, who teaches at the NYU Stern Graduate Business School and CUNY's Baruch College, said that new, broader limits on stock swings that are slated to be tested by regulators in February would have helped.</p><span id="midArticle_10"></span><p>If the latest cars can sense approaching objects and stop automatically, "we need those kinds of controls" in the markets as well, he added.</p><span id="midArticle_11"></span><p>In the old days, it was simpler: human traders known as "specialists" worked on the floors of stock exchanges, such as the New York Stock Exchange, to match buyers with sellers and complete trades themselves if matches couldn't be made.</p><span id="midArticle_12"></span><p>But over the past decade, those specialists have been replaced by automated trading systems, and much trading volume has moved away from exchanges and into other venues, such as "dark pools" - trading systems that let investors anonymously buy or sell larger blocks of stock without tipping their hand to a wider market.</p><span id="midArticle_13"></span><p>Knight Capital, which makes most of its money by executing trades for other brokerage firms, said that a new trading system it installed sent a flood of bogus trades to the market. The loss means that the firm is now fighting for its survival.</p><span id="midArticle_14"></span><p>BETTER TESTING</p><span id="midArticle_15"></span><p>Outsiders questioned why Knight did not pre-test the new software more assiduously, and why the bad trades continued to be generated for more than half an hour, instead of being shut down by internal systems almost immediately.</p><span id="midArticle_0"></span><p>New York quantitative hedge fund owner Roy Niederhoffer said that there was "no excuse" for Knight failing to act sooner.</p><span id="midArticle_1"></span><p>"This is like a nuclear reactor or aircraft," said Niederhoffer, whose R.G. Niederhoffer Capital Management uses Knight. "There has to be some way of seeing the state of the whole system."</p><span id="midArticle_2"></span><p>Trading system glitches often arise with the installation of new systems or computer code. But experts said that market participants constantly need new systems to accommodate new rules and changing customer demands - particularly from high-frequency traders.</p><span id="midArticle_3"></span><p>For example, many trading systems were modified this week to conform with a new retail order-taking system introduced at the New York Stock Exchange and to accommodate a French securities transaction tax that took effect on Wednesday.</p><span id="midArticle_4"></span><p>The U.S. Securities and Exchange Commission has been grappling for years with ways to create a national market system that uses technology to ensure that orders to buy and sell shares are sent to the best possible exchange, dark pool, or other venue. After the shock of the 2010 Flash Crash, it also began exploring fail-safe mechanisms to prevent technology-induced disasters.</p><span id="midArticle_5"></span><p>Some of those measures, including halting trading in a stock that rises or falls beyond predetermined limits, kicked in on Wednesday, protecting investors but not saving Knight from losing big.</p><span id="midArticle_6"></span><p>To be sure, many experts pooh-poohed the wider significance of Knight's problem.</p><span id="midArticle_7"></span><p>"Coding problems happen, but it's not an industry issue," said Matt Andresen, founder of proprietary quantitative trading firm Headlands Technology and a former trading head at a Knight competitor. "I don't know what happened at Knight, but they had a self-inflicted problem that only hurt them. That's the way the market is supposed to work."</p><span id="midArticle_8"></span><p>Maureen O'Hara, a finance professor at Cornell University who sat on a special advisory panel that explored Flash Crash reforms, agreed. "I'm very worried people will take a look and say there is something fundamentally wrong with the market, and there isn't," she said.</p><span id="midArticle_9"></span><p>Some traders and critics said that more details need to come out before they could draw too many conclusions other than the importance of software testing.</p><span id="midArticle_10"></span><p>One thing that's clear: the financial system is much more elaborate now than it was a decade ago, and finding solutions to market problems is not easy.</p><span id="midArticle_11"></span><p>"We have a very complex financial system, bordering on the baroque," said NYU's Donefer.</p><span id="midArticle_12"></span><p>(Reporting By Jed Horowitz, Daniel Wilchins and Lauren Tara LaCapra in New York, Joseph Menn in San Francisco, Sarah Lynch in Washington and Jeff Lukes in London. Writing by Dan Wilchins and Jed Horowitz; Editing by <a href="http://blogs.reuters.com/search/journalist.php?edition=us&n=martin.howell&">Martin Howell</a> and Muralikumar Anantharaman)</p><span id="midArticle_13"></span></span>
+
+<div id="relatedStocks2"><div class="module">
+				<div class="moduleHeader">
+					<h3>Related Quotes and News</h3>
+				</div>
+				<div class="moduleBody">
+					<div class="col1 header">Company</div>
+					<div class="col2 header">Price</div>
+					<div class="col3 header">Related News</div>
+					<div id="relatedStocksList"></div>
+				</div>
+			</div>
+			<script type="text/javascript">
+				Reuters.info.sRelatedStocks = 'BATS.Z,FB.O,KCG.N,NDAQ.O,UBSN.VX';
+			</script>
+			<script type="text/javascript" src="http://s1.reutersmedia.net/resources_v2/js/articleCompanyQuotes2.js"></script>
+	</div><div class="linebreak"></div>
+	<div class="facebookRec" tns="no">
+		<iframe src="http://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2012%2F08%2F03%2Fus-knightcapital-trading-technology-idUSBRE87203X20120803&amp;layout=standard&amp;show_faces=false&amp;width=450&amp;action=recommend&amp;colorscheme=light&amp;height=35" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:450px; height:35px;" allowTransparency="true"></iframe>
+        </div>
+<div class="module shareLinks horizontal">
+	     <div class="moduleBody">
+	        <ul>
+
+                <li class="twitter " tns="no">
+                   		<span class="hrefClone" onclick="Reuters.tns.retweet();">Tweet this</span>
+					</li>
+                <li class="linkedIn " tns="no">
+                       	<span class="hrefClone" onclick="Reuters.utils.popup('http://www.linkedin.com/shareArticle?mini=true&source=Reuters&url=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2012%2F08%2F03%2Fus-knightcapital-trading-technology-idUSBRE87203X20120803&title=Knight+trading+loss+shows+cracks+in+equity+markets&summary=By+Jed+Horowitz+and+Joseph+Menn%0A%28Reuters%29+-+The+software+glitch+that+cost+Knight+Capital+Group+%24440+million+in+just+45+minutes+reveals+the+deep+fault+lines+in+stock+markets+that+are+increasingly+dominated+by+sophisticated+high-speed+trading+systems....', 520, 570, 1, 'shareArticle');">Link this</span>
+                 	</li>
+	            <li class="facebook" tns="no"><span class="hrefClone" onclick="Reuters.utils.popup('http://www.facebook.com/sharer.php?u=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2012%2F08%2F03%2Fus-knightcapital-trading-technology-idUSBRE87203X20120803&t=Knight+trading+loss+shows+cracks+in+equity+markets', 626, 436, 1, 'shareArticle');">Share this</span></li>
+	            <li class="digg " tns="no">
+                       	<span class="hrefClone" onclick="Reuters.utils.popup('http://digg.com/submit?url=http%3A%2F%2Fwww.reuters.com%2Farticle%2F2012%2F08%2F03%2Fus-knightcapital-trading-technology-idUSBRE87203X20120803&bodytext=Knight+trading+loss+shows+cracks+in+equity+markets', 1062, 570, 1, 'shareArticle');">Digg this</span>
+	                </li>
+	            <li tns="no" class="email"><span class="hrefClone" onclick="Reuters.utils.popup('/do/emailArticle?articleId=USBRE87203X20120803', 580, 735, 1, 'emailArticle');">Email</span></li>
+			<li tns="no" class="reprints"><a href="http://www.reutersreprints.com">Reprints</a></li>
+            </ul>
+	    </div>
+	</div>
+<div class="section">
+	<div class="sectionContent">
+<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<script type="text/javascript">
+	Reuters.namespace("info");
+	Reuters.info.outbrain_env = 'produsx';
+</script>
+<script type="text/javascript">
+document.write('<div class="OUTBRAIN" data-src="http://www.reuters.com' + Reuters.info.articleUrl + '?env' + Reuters.info.outbrain_env +'=0" data-widget-id="AR_2" data-ob-template="reuters" ></div>');
+</script>
+<script type="text/javascript" src="http://widgets.outbrain.com/outbrain.js"></script>
+<div class="linebreak"></div>
+	</div>
+
+</div>
+
+</div>
+</div>
+
+
+<div class="section">
+	<div class="sectionContent">
+<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<script type="text/javascript">
+	Reuters.namespace("info");
+	Reuters.info.outbrain_env = 'produsx';
+</script>
+<script type="text/javascript">
+document.write('<div class="OUTBRAIN" data-src="http://www.reuters.com' + Reuters.info.articleUrl + '?env' + Reuters.info.outbrain_env +'=0" data-widget-id="AR_3" data-ob-template="reuters" ></div>');
+</script>
+<script type="text/javascript" src="http://widgets.outbrain.com/outbrain.js"></script>
+<div class="linebreak"></div>
+	</div>
+
+</div>
+
+</div>
+</div>
+
+
+<script type="text/javascript">
+    var headlineEncoded = 'Knight+trading+loss+shows+cracks+in+equity+markets';
+    var currentId = 'USBRE87203X20120803';
+    var storyChannel = 'businessNews';
+    var storyEdition = 'BETAUS';
+    var storyURL = 'www.reuters.com';
+    var socialCommentCount = '5';
+    </script>
+    <div id="commentForm">
+    <a name="post">&nbsp;</a>
+    <div>
+    <iframe name="commentFrame" id="commentFrame" src="/assets/commentsChild?canonical_article_id=/article/2012/08/03/us-knightcapital-trading-technology-idUSBRE87203X20120803&articleId=USBRE87203X20120803&headline=Knight+trading+loss+shows+cracks+in+equity+markets&channel=businessNews&edition=BETAUS&view=base" height="290" width="640" frameborder="0" scrolling="no"></iframe>
+    </div>
+    <script type="text/javascript" src="http://s3.reutersmedia.net/resources_v2/js/commentLogin.js"></script>
+    </div>
+    <div class="commentDisclaimer">We welcome comments that advance the story through relevant opinion, anecdotes, links and data. If you see a comment that you believe is irrelevant or inappropriate, you can flag it to our editors by using the report abuse links. Views expressed in the comments do not represent those of Reuters. For more information on our comment policy, see <a href="http://blogs.reuters.com/fulldisclosure/2010/09/27/toward-a-more-thoughtful-conversation-on-stories/">http://blogs.reuters.com/fulldisclosure/2010/09/27/toward-a-more-thoughtful-conversation-on-stories/</a></div>
+<div class="articleComments">
+<div class="commentsHeader">Comments (2)</div>
+<div class="singleComment">
+		<div class="commentAuthor">
+        <a href="/profile/Vuenbelvue">Vuenbelvue</a> wrote:
+        </div>
+   		<div class="commentsBody" <p>Does any company that is a member of the Stock Exchange get any value from the high speed trading? Example: Use of the capital that was invested for that mega-second for plant expansion. If not, isn&#8217;t this just a form of Gambling with profits or losses subjected to IRS tax codes?</p>
+</div>
+    <div class="timestamp">Aug 02, 2012&nbsp;11:09pm EDT&nbsp;&nbsp;--&nbsp;&nbsp;<a href="javascript:Reuters.utils.reportAsAbuse(626317)">Report as abuse</a></div>
+    </div>
+    <div class="singleComment">
+		<div class="commentAuthor">
+        <a href="/profile/TheUSofA">TheUSofA</a> wrote:
+        </div>
+   		<div class="commentsBody" <p>If you want a safe banking and financial system, then you have to recognize that complexity is the enemy. Transparency is not something favored by Wall Street or government.</p>
+<p>Worrying about terrorism pales in comparison to the continuing damage and destruction that the global banking and finance sector has wrought (and continues to do so).</p>
+</div>
+    <div class="timestamp">Aug 03, 2012&nbsp;1:32am EDT&nbsp;&nbsp;--&nbsp;&nbsp;<a href="javascript:Reuters.utils.reportAsAbuse(626372)">Report as abuse</a></div>
+    </div>
+    <div class="socialCommentLinks">
+<span class="seeAllComments"><a href="/article/comments/idUSBRE87203X20120803">See All Comments &#187;</a></span>
+    <span class="addYourComment"><a href="#post">Add Your Comment</a></span>
+    </div>
+</div>
+<br />
+<script language="javascript" src="/assets/inlineArticleLinks"></script><script type="text/javascript" src="http://jlinks.industrybrains.com/jsct?sid=851&amp;ct=REUTERS_INVESTING&amp;tr=NEWS_MARKETS&amp;num=4&amp;layt=1&amp;fmt=simp"></script>
+  
+
+<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "264775" hidden for channel: true
+		    channel: businessNews
+		    include chans: [Banking06, ChinaInvestmentSummit09, ChinaInvestmentSummit10, Defense05, Exchanges06, Finance05, Finance07, Finance08, GlobalEnvironment07, GlobalEnvironment08, Infrastructure09, InvestmentOutlook06, InvestmentOutlook07, InvestmentOutlook07_DUP1, InvestmentOutlook08, InvestmentOutlook09, InvestmentOutlook10, InvestmentOutlookDec10, InvestmentOutlookJan09, InvestmentOutlookJun10, InvestmentOutlookMid08, Restructuring08, Restructuring09, Restructuring10, WealthManagement06, WealthManagement07, WealthManagement08, WealthManagement10, AerospaceandDefense07, AerospaceandDefense08, AerospaceandDefense09, AerospaceandDefense10, AerospaceDefense06, Autos05, Autos06, Autos07, Autos08, Autos09, Autos10, AutosII08, Banking, Biotechnology06, CentralEuropeanInvestment07, CentralEuropeanInvestment08, CentralEuropeanInvestment09, CentralEuropeanInvestment10, Chemicals06, ChinaCentury06, ConsumerandRetail07, ConsumerandRetail08, CorporateFinance05, ExchangesandTrading07, ExchangesandTrading08, Food, Food06, Food07, Food08, FoodandAgriculture09, FoodandAgriculture10, Funds05, Funds08, Funds09, Funds10, GlobalAgricultureandBiofuels08, GlobalBiofuel07, GlobalClimateandAlternativeEnergy09, GlobalClimateandAlternativeEnergy10, GlobalEnergy06, GlobalEnergy07, GlobalEnergy08, GlobalEnergy09, GlobalEnergy10, GlobalExchangesandTrading09, GlobalExchangesandTrading10, GlobalFinance09, GlobalFinancialRegulation09, GlobalFinancialRegulation10, GlobalHedgeFundandPrivateEquity07, GlobalLuxury09, GlobalLuxury10, GlobalMedia09, GlobalMedia10, GlobalMining06, GlobalMiningandSteel07, GlobalMiningandSteel08, GlobalMiningandSteel09, GlobalMiningandSteel10, GlobalRealEstate08, GlobalRealEstate09, GlobalRealEstate10, GlobalRetail09, GlobalRetail10, GlobalTech06, GlobalTechnology09, GlobalTechnology10, GlobalWealthManagement09, GlobalWealthManagement10, GCA-Housing, GCA-PersonalFinance, fundsFundsNews], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "210248" hidden for channel: true
+		    channel: businessNews
+		    include chans: [SmallBusinessBlog, SmallBusinessDup, SmallBusinessFedex, smallBusinessGrowthNews, smallBusinessInnovationNews, smallBusinessLeadershipNews, smallBusinessNews, smallBusinessStartupNews, smallBusinessTopNews, entrepreneur, bigMoney, deborahCohen, findLawAttributedNews, GCA-smallBusinessLaw, personalFinanceLindaStern], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "210250" hidden for channel: true
+		    channel: businessNews
+		    include chans: [Tech, TechLife, technology-media-telco-SP, technology-media-telco-SP-A, Technology08, TechnologyMediaTelecoms07, technologyNews, technologyPhotos, technologySector, TechVerizonMar10, internetNews], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "210827" hidden for channel: true
+		    channel: businessNews
+		    include chans: [health-SP, health-SP-A, Health06, Health07, Health08, Health09, Health10, HealthCare05, healthcareSector, healthNews], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "210825" hidden for channel: true
+		    channel: businessNews
+		    include chans: [entertainmentNews, entertainmentNewsPhotos, Art, artsNews, filmNews, musicNews, peopleNews, reviewsNews, televisionNews, boxOfficeCharts, billboardCharts], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "210237" hidden for channel: true
+		    channel: businessNews
+		    include chans: [Currencies, asianCurrencyNews, usDollarRpt, europeanCurrencyNews, forexNews, forexNewsCopy], empty: false
+		    exclude chans: , empty: true
+		-->
+		<div class="linebreak"></div>
+	<!--
+		  SHARED MODULE ID: "264780" hidden for channel: true
+		    channel: businessNews
+		    include chans: , empty: true
+		    exclude chans: [lifestyleMolt, technologyNews, healthNews, entertainmentNews, Deals, hotStocksNews, hedgeFundsNews, privateEquity, marketsNews, smallBusinessNews, globalMarketsNews, bankruptcyNews, bondsNews, domesticNews, GCA-Economy2010, GCA-GreenBusiness, goldMktRpt, industryNews, internal_ReutersNewsRoom_ExclusivesAndWins_MOLT, mergersNews, ousivMolt, asianCurrencyNews, businessNews, economicNews, usDollarRpt, usMktRpt, SmallBusinessBlog, SmallBusinessDup, SmallBusinessFedex, smallBusinessGrowthNews, smallBusinessInnovationNews, smallBusinessLeadershipNews, smallBusinessStartupNews, smallBusinessTopNews, SmallBusinessVideo, TechLife, technology-media-telco-SP, technology-media-telco-SP-A, Technology08, TechnologyMediaTelecoms07, technologyPhotos, technologySector, TechVerizonMar10, health-SP, health-SP-A, Health06, Health07, Health08, Health09, Health10, HealthCare05, healthcareSector, entertainmentNewsPhotos, companyNews, rbssAdvancedMedicalEquipment, rbssAdvertisingMarketing, rbssAerospaceDefense, rbssAirFreightCourierServices, rbssAirlines, rbssAirportServices, rbssAluminum, rbssApparelAccessories, rbssAppliancesToolsHousewares, rbssAutoTruckManufacturers, rbssAutoTruckMotorcycleParts, rbssBanks, rbssBeveragesBrewers, rbssBeveragesDistillersWineries, rbssBeveragesNonAlcoholic, rbssBiotechnology, rbssBroadcasting, rbssCasinosGaming, rbssChemicalsAgricultural, rbssChemicalsCommodity, rbssChemicalsDiversified, rbssChemicalsSpecialty, rbssCoal, rbssCommercialPrinting Services, rbssCommercialServices & Supplies, rbssCommunicationsEquipment, rbssComputerHardware, rbssConstructionAgriculturalMachinery, rbssConstructionMaterials, rbssConstructionSuppliesFixtures, rbssConsumerElectronics, rbssConsumerFinancialServices, rbssConsumerGoodsAndRetailNews, rbssDiversifiedTradingDistribution, rbssElectricalComponentsEquipment, rbssEnergyNews, rbssEngineeringConstruction, rbssEntertainmentProduction, rbssEnvironmentalServices, rbssFinancialServices - Diversified, rbssFinancialServicesAndRealEstateNews, rbssFinancialsSpecialty, rbssFishingFarming, rbssFoodDistribution & Convenience Stores, rbssFoodProcessing, rbssFootwear, rbssForestWoodProducts, rbssHealthcareFacilities, rbssHealthcareNews, rbssHeavyElectricalEquipment, rbssHighwaysRailroads, rbssHomebuilding, rbssHomeFurnishing, rbssHotels, rbssHouseholdProducts, rbssIndustrialConglomerates, rbssIndustrialMachineryEquipment, rbssIndustryMaterialsUtilitiesNews, rbssInsuranceLifeHealth, rbssInsuranceMultiline, rbssInsuranceProperty & Casualty, rbssIntegratedOilGas, rbssIntegratedTelecommunicationsServices, rbssInvestmentServices, rbssInvestmentTrusts, rbssITServicesConsulting, rbssLeisureProducts, rbssLeisureRecreation, rbssManagedHealthCare, rbssMarinePortServices, rbssMarineTransportation, rbssMediaDiversified, rbssMedicalEquipment, Supplies & Distribution, rbssMiningMetalsSpecialty, rbssNonPaperContainersPackaging, rbssOfficeEquipment, rbssOilGasDrilling, rbssOilGasExplorationProduction, rbssOilGasRefiningMarketing, rbssOilRelatedServicesEquipment, rbssPaperPackaging, rbssPaperProducts, rbssPersonalProducts, rbssPersonalServices, rbssPharmaceuticals - Diversified, rbssPharmaceuticals - Generic & Specialty, rbssPreciousMetalsMinerals, rbssPublishing, rbssRailsRoadsFreights, rbssRailsRoadsPassengers, rbssRealEstateOperations, rbssReinsurance, rbssREITResidentialCommercial, rbssRestaurants, rbssRetailApparelAccessories, rbssRetailCatalogInternetOrder, rbssRetailComputersElectronics, rbssRetailDepartmentStores, rbssRetailDiscountStores, rbssRetailDrugs, rbssRetailSpecialty, rbssSemiconductorEquipmentTesting, rbssSemiconductors, rbssSoftware, rbssSteel, rbssTechMediaTelecomNews, rbssTextilesLeatherGoods, rbssTiresRubberProducts, rbssTobacco, rbssUtilitiesElectric, rbssUtilitiesMultiline, rbssUtilitiesNaturalGas, rbssUtilitiesWater & Others, rbssWirelessTelecommunicationServices, huginPressRelease, utilitiesSector, nonCyclicalConsumerGoodsSector, industrialsSector, financialsSector, cyclicalConsumerGoodsSector, basicMaterialsSector, innovationNews, governmentFilingsNews, pressRelease, Amtrak, Amtrak2, ukPoundRpt, weekAheadWallStreet, newsOne, internetNews, artsNews, billboardCharts, boxOfficeCharts, filmNews, musicNews, peopleNews, reviewsNews, televisionNews, ousiv, eurMktRpt, franceMktRpt, germanyMktRpt, hongkongMktRpt, londonMktRpt, singaporeMktRpt, swissMktRpt, tokyoMktRpt, amsterdamMktRpt, belgiumMktRpt, brazilMktRpt, canadaMktRpt, chileMktRpt, mexicoMktRpt, spainMktRpt, weekAheadG7, Banking06, ChinaInvestmentSummit09, ChinaInvestmentSummit10, Defense05, Exchanges06, Finance05, Finance07, Finance08, GlobalEnvironment07, GlobalEnvironment08, InvestmentOutlook07, InvestmentOutlook07_DUP1, InvestmentOutlook08, InvestmentOutlook09, InvestmentOutlook10, InvestmentOutlookDec10, InvestmentOutlookJan09, InvestmentOutlookJun10, InvestmentOutlookMid08, Media05, Media08, Restructuring08, Restructuring09, Restructuring10, WealthManagement06, WealthManagement07, WealthManagement08, WealthManagement10, AerospaceandDefense07, AerospaceandDefense08, AerospaceandDefense09, AerospaceandDefense10, AerospaceDefense06, Autos05, Autos06, Autos07, Autos08, Autos09, Autos10, AutosII08, Banking, Biotechnology06, CentralEuropeanInvestment07, CentralEuropeanInvestment08, CentralEuropeanInvestment09, Chemicals06, ChinaCentury06, ConsumerandRetail07, ConsumerandRetail08, CorporateFinance05, ExchangesandTrading07, ExchangesandTrading08, Food, Food06, Food07, Food08, FoodandAgriculture09, FoodandAgriculture10, GlobalAgricultureandBiofuels08, GlobalBiofuel07, GlobalEnergy06, GlobalEnergy07, GlobalEnergy08, GlobalEnergy09, GlobalEnergy10, GlobalExchangesandTrading09, GlobalExchangesandTrading10, GlobalFinance09, GlobalFinancialRegulation09, GlobalFinancialRegulation10, GlobalHedgeFundandPrivateEquity07, GlobalLuxury09, GlobalLuxury10, GlobalMedia09, GlobalMedia10, GlobalMining06, GlobalMiningandSteel07, GlobalMiningandSteel08, GlobalMiningandSteel09, GlobalMiningandSteel10, GlobalRealEstate08, GlobalRealEstate09, GlobalRealEstate10, GlobalRetail09, GlobalRetail10, GlobalTech06, GlobalTechnology09, GlobalTechnology10, GlobalWealthManagement09, GlobalWealthManagement10, GCA-Housing, GCA-PersonalFinance, fundsFundsNews, gc03, PersonalFinance], empty: false
+		-->
+		<div class="linebreak"></div>
+	</div>
+
+</div>
+
+<script type="text/javascript" src="https://apis.google.com/js/plusone.js">
+{"parsetags": "explicit"}
+</script>
+<script type="text/javascript">
+gapi.plusone.go("googleTag");
+</script>
+</div>
+</div>
+<div class="section">
+	<div class="sectionContent">
+<div class="sectionColumns">
+
+<div class="column1">
+</div>
+
+<div class="column2">
+</div>
+
+<div class="column3">
+</div>
+
+</div>
+
+<div id="articleFooter"><div id="cobrandLoader"> </div><div class="linebreak"></div>
+	<!--[if !IE]>Start Network Footer<![endif]-->
+<link href="/resources_v2/css/rcom-network-footer.css" rel="stylesheet" />
+<script language="javascript" src="/resources_v2/js/rcom-network-footer.js"></script>
+<div id="network-footer"></div>
+<script language="javascript">Reuters.utils.replaceContent("network-footer", "/assets/sharedModuleLoader?view=RSM-US-More-From-Reuters-2", null, Reuters.utils.fixNetworkFooter);</script>
+<div class="linebreak"></div>
+
+
+<!--[if !IE]>End Network Footer<![endif]-->
+<!--[if !IE]> START News Content Page Tags <![endif]-->
+<META name="DCSext.ContentType" content="Text"> <!--[if !IE]> 'Text' | 'Picture' | 'Slideshow' | 'Video' <![endif]-->
+<META name="DCSext.ContentID" content="USBRE87203X20120803"> <!--[if !IE]> ie. articleId <![endif]-->
+<META name="DCSext.ContentChannel" content="businessNews">
+<META name="DCSext.ContentID_businessNews" content="USBRE87203X20120803"> <!--[if !IE]> ie. articleId <![endif]-->
+<META name="DCSext.ContentHeadline" content="Knight+trading+loss+shows+cracks+in+equity+markets"> <!--[if !IE]> ie. headline for article <![endif]-->
+<META name="DCSext.PageNumber"      content="1">
+<META name="DCSext.PageTotal"       content="2"> <!--[if !IE]> ie. headline for article <![endif]-->
+<!--[if !IE]> END News Content Page Tags <![endif]-->
+<script src="/resources_v2/js/tracker_article.js" type="text/javascript"></script>
+</div></div>
+</div>
+<div class="section bleeding" id="footerHead">
+	<div class="sectionContent">
+<div id="footerHeader"><div class="columnLeft"><div class="logo"><div id="footerLogo"><a href="/">&nbsp;</a></div></div></div><div class="columnLeft">	<div id="editionsFooter" class="panel editions">
+			<ul id="editionSwitchFooter" class="editionSwitch">
+				<li>
+					<div class="currentEditionTitle">Edition:</div>
+					<div class="currentEdition">U.S.</div>
+					<div class="editionArrow"></div>
+					<ul>
+						<li><a href="http://af.reuters.com">Africa</a></li>
+						<li><a href="http://ara.reuters.com">Arabic</a></li>
+						<li><a href="http://ar.reuters.com">Argentina</a></li>
+						<li><a href="http://br.reuters.com">Brazil</a></li>
+						<li><a href="http://ca.reuters.com">Canada</a></li>
+						<li><a href="http://cn.reuters.com">China</a></li>
+						<li><a href="http://fr.reuters.com">France</a></li>
+						<li><a href="http://de.reuters.com">Germany</a></li>
+						<li><a href="http://in.reuters.com">India</a></li>
+						<li><a href="http://it.reuters.com">Italy</a></li>
+						<li><a href="http://jp.reuters.com">Japan</a></li>
+						<li><a href="http://lta.reuters.com">Latin America</a></li>
+						<li><a href="http://mx.reuters.com">Mexico</a></li>
+					    <li><a href="http://ru.reuters.com">Russia</a></li>
+						<li><a href="http://es.reuters.com">Spain</a></li>
+						<li><a href="http://uk.reuters.com">United Kingdom</a></li>
+					</ul>
+				</li>
+			</ul>
+		</div>
+<script type="text/javascript">
+if(Reuters.info.edition == "BETAUS") {
+	$("#editionSwitchFooter .currentEdition").text('U.S.');
+} else {
+	$("#editionSwitchFooter .currentEdition").text(Reuters.info.edition);
+}
+</script></div><div class="columnRight"><div id="topLink"><a href="#top"><p>Back to top</p></a></div></div></div><div class="sectionColumns">
+
+<div class="column1">
+</div>
+
+<div class="column2">
+</div>
+
+<div class="column3">
+</div>
+
+</div>
+
+</div>
+</div>
+<div class="section bleeding" id="footer">
+	<div class="sectionContent">
+<div class="sectionColumns">
+
+<div class="gridPanel grid12">
+<div class="columnLeft"><div class="gridPanel grid12">
+<span class="footerparent">Reuters.com</span>
+<ul>
+	<li class="h-links"><a href="http://www.reuters.com/finance">Business</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/finance/markets">Markets</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/news/world">World</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/news/politics">Politics</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/news/technology">Technology</a></li>
+	<li class="h-links"><a href="http://blogs.reuters.com/us/">Opinion</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/finance/personal-finance">Money</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/news/pictures">Pictures</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/news/video">Videos</a></li>
+	<li class="h-linkend"><a href="http://www.reuters.com/assets/siteindex">Site Index</a></li>
+</ul>
+
+
+
+</div></div><div class="columnLeft"><div class="gridPanel grid12"><span class="footerparent"><a href="http://newsandinsight.thomsonreuters.com/Legal/" target="_blank">Legal</a></span>
+<ul>
+	<li class="h-links"><a href="http://newsandinsight.thomsonreuters.com/Legal/Bankruptcy/" target="_blank" onclick="dcsMultiTrack('DCS.dcssip','newsandinsight.thomsonreuters.com','DCS.dcsuri','/Legal/Bankruptcy/','WT.ti','Offsite: newsandinsight.thomsonreuters.com','WT.dl','24','WT.z_offsite','http://newsandinsight.thomsonreuters.com/Legal/Bankruptcy/');">Bankruptcy Law</a></li>
+	<li class="h-links"><a href="http://newsandinsight.thomsonreuters.com/Legal/CA/" target="_blank" onclick="dcsMultiTrack('DCS.dcssip','newsandinsight.thomsonreuters.com','DCS.dcsuri','/Legal/CA/','WT.ti','Offsite: newsandinsight.thomsonreuters.com','WT.dl','24','WT.z_offsite','http://newsandinsight.thomsonreuters.com/Legal/CA/');">California Legal</a></li>
+	<li class="h-links"><a href="http://newsandinsight.thomsonreuters.com/Legal/NY/" target="_blank" onclick="dcsMultiTrack('DCS.dcssip','newsandinsight.thomsonreuters.com','DCS.dcsuri','/Legal/NY/','WT.ti','Offsite: newsandinsight.thomsonreuters.com','WT.dl','24','WT.z_offsite','http://newsandinsight.thomsonreuters.com/Legal/NY/');">New York Legal</a></li>
+	<li class="h-linkend"><a href="http://newsandinsight.thomsonreuters.com/Legal/Securities/" target="_blank" onclick="dcsMultiTrack('DCS.dcssip','newsandinsight.thomsonreuters.com','DCS.dcsuri','/Legal/Securities/','WT.ti','Offsite: newsandinsight.thomsonreuters.com','WT.dl','24','WT.z_offsite','http://newsandinsight.thomsonreuters.com/Legal/Securities/');">Securities Law</a></li>
+</ul></div></div><div class="columnLeft"><div class="gridPanel grid12"><span class="footerparent">Support & Contact</span>
+<ul>
+	<li class="h-links"><a href="http://reuters.zendesk.com">Support</a></li>
+	<li class="h-linkend"><a href="http://reuters.zendesk.com/anonymous_requests/new">Corrections</a></li>
+</ul>
+</div></div><div class="columnLeft"><div id="footer-utilities" class="gridPanel grid12"></div></div><div class="columnLeft"><div class="gridPanel grid12">
+<span class="footerparent">Connect with Reuters</span>
+<ul>
+<li id="foot-twitter"><a href="http://www.twitter.com/reuters">Twitter</a>&nbsp;&nbsp;</li>
+<li id="foot-facebook"><a href="http://www.facebook.com/Reuters">Facebook</a>&nbsp;&nbsp;</li>
+<li id="foot-linkedin"><a href="http://www.linkedin.com/today/reuters.com">LinkedIn</a>&nbsp;&nbsp;</li>
+<li id="foot-rssfeed"><a href="http://www.reuters.com/tools/rss">RSS</a>&nbsp;&nbsp;</li>
+<li id="foot-podcasts"><a href="http://www.reuters.com/tools/podcasts">Podcast</a>&nbsp;&nbsp;</li>
+<li id="foot-newsletters"><a href="https://commerce.us.reuters.com/profile/pages/newsletter/begin.do">Newsletters</a>&nbsp;&nbsp;</li>
+<li id="foot-mobile"><a href="http://www.reuters.com/tools/mobile">Mobile</a></li>
+</ul>
+</div></div><div class="columnLeft"><div class="gridPanel grid12"><span class="footerparent">About</span>
+<ul>
+	<li class="h-links"><a href="http://www.reuters.com/privacy-policy">Privacy Policy</a></li>
+	<li class="h-links"><a href="http://www.reuters.com/terms-of-use">Terms of Use</a></li>
+         <li class="h-links" id="evidon-footer"><a id="_bapw-link" href="#" target="_blank"><img id="_bapw-icon" border="0" src="http://cdn.betrad.com/pub/icon1.png" /><span id="evidon-text">AdChoices</span></a></li>
+	<li class="h-linkend" id="footer-endrow"><a href="http://thomsonreuters.com/copyright/">Copyright</a></li>
+</ul>
+<script>/**/(function(){var g=285,i=1237,a=false,h=document,j=h.getElementById("_bapw-link"),e=(h.location.protocol=="https:"),f=(e?"https":"http")+"://",c=f+(e?"a248.e.akamai.net/betterad.download.akamai.com/91609":"cdn.betrad.com")+"/pub/";function b(k){var d=new Image();d.src=f+"l.betrad.com/pub/p.gif?pid="+g+"&ocid="+i+"&i"+k+"=1&r="+Math.random()}h.getElementById("_bapw-icon").src=c+"icon1.png";j.onmouseover=function(){if(/#$/.test(j.href)){j.href="http://info.evidon.com/pub_info/"+g+"?v=1"}};j.onclick=function(){var k=window._bap_p_overrides;function d(n,q){var o=h.getElementsByTagName("head")[0]||h.documentElement,m=a,l=h.createElement("script");function p(){l.onload=l.onreadystatechange=null;o.removeChild(l);q()}l.src=n;l.onreadystatechange=function(){if(!m&&(this.readyState=="loaded"||this.readyState=="complete")){m=true;p()}};l.onload=p;o.insertBefore(l,o.firstChild)}if(k&&k.hasOwnProperty(g)){if(k[g].new_window){b("c");return true}}this.onclick="return "+a;d(f+"ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js",function(){d(c+"pub2.js",function(){BAPW.i(j,{pid:g,ocid:i})})});return a};b("i")}());/**/</script>
+</div></div><div id="tr-intro" class="gridPanel grid12"><div id="tr-description"><img src="/resources_v2/images/tr-source-txt.gif" border="0" /></div></div><div class="linebreak"></div>
+	<div id="tr-info" class="gridPanel grid12"><div class="tr-products">
+<div id="tr-eikon">
+<div class="tr-header1"><a href="http://thomsonreuters.com/products_services/financial/eikon/" onclick="dcsMultiTrack('DCS.dcssip','thomsonreuterseikon.com','DCS.dcsuri','/','WT.ti','Offsite: thomsonreuterseikon.com','WT.dl','24','WT.z_offsite','http://thomsonreuterseikon.com/');"></a></div>
+<div class="tr-descr">Our Flagship financial information platform incorporating Reuters Insider</div>
+</div>
+
+<div id="tr-elektron">
+<div class="tr-header1"><a href="http://thomsonreuters.com/products_services/financial/financial_products/a-z/elektron/" onclick="dcsMultiTrack('DCS.dcssip','www.pehub.com','DCS.dcsuri','/','WT.ti','Offsite: www.pehub.com','WT.dl','24','WT.z_offsite','http://www.pehub.com/');"OnClick="dcsMultiTrack('DCS.dcssip','thomsonreuters.com','DCS.dcsuri','/','WT.ti','Offsite: thomsonreuters.com','WT.dl','24','WT.z_offsite','http://thomsonreuters.com/');"></a></div>
+<div class="tr-descr">An ultra-low latency infrastructure for electronic trading and data distribution</div>
+</div>
+
+<div id="tr-accelus">
+<div class="tr-header1"><a href="http://www.accelus.thomsonreuters.com/" onclick="dcsMultiTrack('DCS.dcssip','www.accelus.thomsonreuters.com','DCS.dcsuri','/','WT.ti','Offsite: www.accelus.thomsonreuters.com','WT.dl','24','WT.z_offsite','http://www.accelus.thomsonreuters.com/');"></a></div>
+<div class="tr-descr">A connected approach to governance, risk and compliance</div>
+</div>
+
+<div id="tr-westlaw">
+<div class="tr-header3"><a href="http://west.thomson.com/westlawnext/default.aspx" onclick="dcsMultiTrack('DCS.dcssip','west.thomson.com','DCS.dcsuri','/westlawnext/default.aspx','WT.ti','Offsite: west.thomson.com','WT.dl','24','WT.z_offsite','http://west.thomson.com/westlawnext/default.aspx');"></a></div>
+<div class="tr-descr">Our next generation legal research platform</div>
+</div>
+
+<div id="tr-onesource">
+<div class="tr-header1"><a href="http://onesource.thomsonreuters.com/" onclick="dcsMultiTrack('DCS.dcssip','onesource.thomsonreuters.com','DCS.dcsuri','/','WT.ti','Offsite: onesource.thomsonreuters.com','WT.dl','24','WT.z_offsite','http://onesource.thomsonreuters.com/');"></a></div>
+<div class="tr-descr">Our global tax workstation</div>
+</div>
+
+<div id="tr-linklist">
+<ul>
+<li class="tr-descr"><a href="http://thomsonreuters.com/">Thomsonreuters.com</a></li>
+<li class="tr-descr"><a href="http://thomsonreuters.com/about/">About Thomson Reuters</a></li>
+<li class="tr-descr"><a href="http://ir.thomsonreuters.com">Investor Relations</a></li>
+<li class="tr-descr"><a href="http://careers.thomsonreuters.com/">Careers</a></li>
+<li class="tr-descr"><a href="http://thomsonreuters.com/about/contact_us/">Contact Us</a></li>
+</ul>
+</div>
+
+</div></div><div class="linebreak"></div>
+	<div id="tr-logo" class="gridPanel grid12"><a href="http://www.thomsonreuters.com/"><div id="tr-footer">&nbsp;</div></a></div><div class="linebreak"></div>
+	</div>
+
+</div>
+
+<div id="disclaimer"><p><a href="http://www.thomsonreuters.com">Thomson Reuters</a> is the world's largest international multimedia news agency, providing <a href="http://www.reuters.com/finance/markets/us">investing news</a>, <a href="http://www.reuters.com/news/world">world news</a>, <a href="http://www.reuters.com/finance">business news</a>, <a href="http://www.reuters.com/news/technology">technology news</a>, headline news, <a href="http://www.reuters.com/finance/smallBusiness">small business news</a>, news alerts, <a href="http://www.reuters.com/finance/personal-finance">personal finance</a>, <a href="http://www.reuters.com/finance/stocks">stock market</a>, and <a href="http://funds.us.reuters.com/US/overview.asp">mutual funds information</a> available on Reuters.com, <a href="http://www.reuters.com/news/video">video</a>, <a href="http://www.reuters.com/tools/mobile">mobile</a>, and interactive television platforms. Thomson Reuters journalists are subject to an <a href="http://handbook.reuters.com">Editorial Handbook</a> which requires fair presentation and disclosure of relevant interests.</p>
+
+<p>NYSE and AMEX quotes delayed by at least 20 minutes. Nasdaq delayed by at least 15 minutes. For a complete <a href="http://www.reuters.com/info/disclaimer" target="_blank">list of exchanges and delays, please click here</a>.</p></div><div id="Footer1"></div><img src="http://www.bizographics.com/collect/?fmt=gif&url=reuters.com&pid=501" width="1" height="1" border="0" alt="">
+<div class="linebreak"></div>
+	<script type="text/javascript">
+var _baq = _baq || [];
+_baq.push(['setClientId','e1icvk']);
+_baq.push(['trackPageView']);
+
+_baq.push(['setCustomVariable',1,'section','BETAUS'])
+
+var author = 'Jed Horowitz and Joseph Menn';
+var authorNameList = '';
+if (author != '') {
+    author = author.replace(/<a[^>]*">/g, '');
+    author = author.replace(/<\/a>/g, '');
+    var authors = author.split(' and ');
+    var nameList = '';
+    for (var i=0; i<authors.length; i++) {
+       if (authorNameList != '') {
+            authorNameList = authorNameList.trim() + ";";
+       }
+       authorNameList = authorNameList + authors[i].trim();
+    }
+    authorNameList = authorNameList.replace(",", ";");
+}
+
+if (authorNameList != '') {
+_baq.push(['setCustomVariable',2,'author',authorNameList])
+}
+
+(function () { var s = document.createElement('script'); s.src = ('https:' == document.location.protocol ? 'https://commerce.us.reuters.com' : 'http://mediacdn.reuters.com') + '/pulse/2/trb.js'; (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s); }());
+</script>
+
+</div>
+</div>
+
+
+</div>
+
+<SCRIPT TYPE="text/javascript">
+document.write("<SCR"+"IPT TYPE='text/javascript' SRC='" + "http" + (window.location.protocol.indexOf('https:')==0?'s':'') + "://js.revsci.net/gateway/gw.js?csid=I07714' CHARSET='ISO-8859-1'"+"><\/SCR"+"IPT>");
+</SCRIPT>
+
+<script type="text/javascript">
+<!--
+      I07714.DM_cat("us.reuters > bizfinance > businessnews > article");
+      I07714.DM_tag();
+//-->
+</SCRIPT><!-- Begin comScore Tag -->
+<script type="text/javascript">document.write(unescape("%3Cscript src='" + (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js' %3E%3C/script%3E"));</script>
+<script type="text/javascript">
+	COMSCORE.beacon({ c1:2, c2:"6035630", c3:"", c4:"", c5:"",  c6:"", c15:"" });
+</script>
+<noscript>
+	<img src="http://b.scorecardresearch.com/p?c1=2&c2=&c3=&c4=&c5=&c6=&c15=&cj=1" />
+</noscript>
+<!-- End comScore Tag --><META name="DCSext.rChannel" content="Finance">
+<META name="DCSext.rCountry" content="BETAUS">
+<META name="WT.cg_n" content="Finance - Business News">
+<META name="WT.cg_s" content="businessNews">
+<META name="DCSext.DartZone" content="us.reuters/bizfinance/businessnews/article">
+<script type="text/javascript">
+var loginCookieValue =  YAHOO.util.Cookie.get("login");
+if(loginCookieValue != null && loginCookieValue != ''){
+
+	loginMeta = document.createElement('META');
+	loginMeta.name = 'WT.z_li';
+
+	var customerId = YAHOO.util.Cookie.get("customerId");
+	var socialLoginProvider = YAHOO.util.Cookie.get("socialLoginProvider");
+	if(customerId != null && customerId != '' && socialLoginProvider != null && socialLoginProvider != ''){
+		socialLoginProvider = socialLoginProvider.toLowerCase();
+		if(socialLoginProvider == 'google'){
+			loginMeta.content = "2";
+		} else if(socialLoginProvider == 'facebook'){
+			loginMeta.content = "3";
+		} else if(socialLoginProvider == 'linkedin'){
+			loginMeta.content = "4";
+		} else if(socialLoginProvider=='aol'){
+			loginMeta.content = "5";
+		} else if(socialLoginProvider=='twitter'){
+			loginMeta.content = "6";
+		} else if(socialLoginProvider=='myspace'){
+			loginMeta.content = "7";
+		} else if(socialLoginProvider=='yahoo'){
+			loginMeta.content = "8";
+		}
+	} else {
+		loginMeta.content = "1";
+	}
+
+	document.getElementsByTagName('head')[0].appendChild(loginMeta);
+   }
+
+var registeredCookieValue =  YAHOO.util.Cookie.get("ruus");
+
+if(registeredCookieValue != null && registeredCookieValue != 'undefined' && registeredCookieValue != ''){
+	registeredMeta = document.createElement('META');
+	registeredMeta.name = "WT.z_registered";
+	registeredMeta.content = encodeURIComponent(registeredCookieValue);
+	document.getElementsByTagName('head')[0].appendChild(registeredMeta);
+}
+
+</script>
+<!-- START OF SmartSource Data Collector TAG -->
+<!-- Copyright (c) 1996-2009 WebTrends Inc.  All rights reserved. -->
+<!-- Version: 8.6.0 -->
+<!-- Tag Builder Version: 2.1.0  -->
+<!-- Created: 2/9/2009 17:21:12 -->
+<script src="http://s4.reutersmedia.net/resources_v2/js/webtrends.js" type="text/javascript"></script>
+<script type="text/javascript">
+var _tag=new WebTrends();
+_tag.dcsGetId();
+</script>
+<script type="text/javascript">
+setModuleImpressionTracking();
+_tag.dcsCollect();
+dscQuantcast(_tag);
+</script>
+<noscript>
+<div><img alt="DCSIMG" id="DCSIMG" width="1" height="1" src="http://statse.webtrendslive.com/dcsncwimc10000kzgoor3wv9x_3f2v/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=8.6.0"/></div>
+</noscript>
+<!-- END OF SmartSource Data Collector TAG -->
+
+<script type="text/javascript">
+var _gaq = _gaq || [];
+_gaq.push(['_setAccount', 'UA-24152976-1']);
+_gaq.push(['_setDomainName', '.reuters.com']);
+_gaq.push(['_trackPageview']);
+
+(function() { var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();
+</script>
+
+<!-- Begin BlueKai Tag -->
+<iframe name="__bkframe" height="0" width="0" frameborder="0" src="javascript:void(0)"></iframe>
+<script type="text/javascript" src="http://www.bkrtx.com/js/bk-static.js"></script>
+
+<script>
+	try{		
+		var bkSocialLogin = (typeof socialLoginProvider!="undefined"?socialLoginProvider:"");
+		var bkReferrer = (typeof document.referrer.split("/")[2]!="undefined"?document.referrer.split("/")[2]:"");
+		var bkLoginCookieValue = (typeof loginCookieValue!="undefined"?loginCookieValue:"");
+		var bkSearchVal = (typeof document.location.search!="undefined"?document.location.search:"");
+		var bkRegVal = (typeof registeredCookieValue!="undefined"?registeredCookieValue:"");
+		var bkWTFPCCookie = (typeof YAHOO.util.Cookie.get("WT_FPC")!="undefined"?YAHOO.util.Cookie.get("WT_FPC"):"");
+		
+		bkWTFPCCookieArr = bkWTFPCCookie.split("="); 
+		bkWTFPCCookieKeyArr = bkWTFPCCookieArr[1].split(":");
+		bkWTFPCCookieKey = bkWTFPCCookieKeyArr[0];
+		
+		//Get Meta Values from Cookie
+		var bkMetaArray = document.getElementsByTagName("meta");
+		for(var i=0;i<bkMetaArray.length;i++){
+			if(bkMetaArray[i].getAttribute("name")){			
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.rChannel")>-1){
+					bk_addPageCtx("rch", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.rCountry")>-1){
+					bk_addPageCtx("rco", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("WT.cg_n")>-1){
+					bk_addPageCtx("wcntn", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("WT.cg_s")>-1){
+					bk_addPageCtx("wcnts", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.ContentChannel")>-1){
+					bk_addPageCtx("cc", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.ContentType")>-1){
+					bk_addPageCtx("cnt", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.PageNumber")>-1){
+					bk_addPageCtx("pn", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.PageTotal")>-1){
+					bk_addPageCtx("pt", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.VideoType")>-1){
+					bk_addPageCtx("vt", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.rAuthor")>-1){
+					bk_addPageCtx("aut", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.Comments")>-1){
+					bk_addPageCtx("com", bkMetaArray[i].getAttribute("content"));
+				}
+				if(bkMetaArray[i].getAttribute("name").indexOf("DCSext.DartZone")>-1){
+					var bkZoneArray = bkMetaArray[i].getAttribute("content").split("/");
+					for(var z=0;z<bkZoneArray.length;z++){
+						var bkHint = "z"+z;
+						bk_addPageCtx(bkHint, bkZoneArray[z]);
+					}
+				}
+			}
+		}
+		bk_addPageCtx("wtc", bkWTFPCCookieKey);	
+		bk_addPageCtx("log", bkLoginCookieValue);
+		bk_addPageCtx("soc", bkSocialLogin);
+		bk_addPageCtx("hsh", bkRegVal);
+		bk_addPageCtx("ref", bkReferrer);
+		bk_addPageCtx("sea", bkSearchVal);
+		bk_doJSTag(4972, 10);
+	}	
+	catch(e){}
+</script>
+<!-- End BlueKai Tag -->
+
+</body>
+</html>
+


### PR DESCRIPTION
The article image will now be extracted from metadata first, that is:
- og:image meta
- twitter:image meta
- image_src link
- thumbnail meta

If none of the above returns a URL, then the images are then extracted from the content itself as done previously.
