### PR TITLE
Prevent images with more than 512 characters

### DIFF
--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -69,7 +69,7 @@ public class ArticleTextExtractor {
         Pattern.compile("By\\S*(.*)[\\.,].*")
     );
     private static final int MAX_AUTHOR_DESC_LENGTH = 1000;
-    private static final int MAX_IMAGE_LENGTH = 290;
+    private static final int MAX_IMAGE_LENGTH = 512;
 
     // For debugging
     private static final boolean DEBUG_WEIGHTS = false;

--- a/src/test/resources/de/jetwick/snacktory/adverts.ie.html
+++ b/src/test/resources/de/jetwick/snacktory/adverts.ie.html
@@ -29,7 +29,7 @@ http://www.adverts.ie/jobs/distilled-media/
 
         <meta property="og:url" content="http://www.adverts.ie/lego-building-toys/lego-general-zod-minifigure-brand-new/5980084">
                 <meta property="og:title" content="Lego General Zod Minifigure Brand New For Sale in Tralee, Kerry from dlaw1">
-                <meta property="og:image" content="http://a1.dmlimg.com/YTBjNzA2YTI4NTMwMWNkZWYxN2ZlMTgzY2Q3NTMyMzQrzZVRKugLPT0xB2z76cMsaHR0cDovL21lZGlhLmFkc2ltZy5jb20vYzgxNWVjZTllMGU2ZGIzODNmZmFhYzRhOWUzNTE4OTExOGNlNjg2NjQ4ZjM4NTU4OWU0OWJhN2U2YjgwOGYyNi5qcGd8fHx8fHwzOTN4Mjk0fGh0dHA6Ly93d3cuYWR2ZXJ0cy5pZS9zdGF0aWMvaS93YXRlcm1hcmsucG5nfHx8.jpg">
+                <meta property="og:image" content="http://a1.dmlimg.com/YTBjNzA2YTI4NTMwMWNkZWYxN2ZlMTgzY2Q3NTMyMzQrzZVRKugLPT0xB2z76cMsaHR0cDovL21lZGlhLmFkc2ltZy5jb20vYzgxNWVjZTllMGU2ZGIzODNmZmFhYzRhOWUzNTE4OTExOGNlNjg2NjQ4ZjM4NTU4OWU0OWJhN2U2YjgwOGYyNi5qcGd8fHx8fHwzOTN4Mjk0fGh0dHA6Ly93d3cuYWR2ZXJ0cy5pZS9zdGF0aWMvaS93YXRlcm1hcmsucG5nfHx8YTBjNzA2YTI4NTMwMWNkZWYxN2ZlMTgzY2Q3NTMyMzQrzZVRKugLPT0xB2z76cMsaHR0cDovL21lZGlhLmFkc2ltZy5jb20vYzgxNWVjZTllMGU2ZGIzODNmZmFhYzRhOWUzNTE4OTExOGNlNjg2NjQ4ZjM4NTU4OWU0OWJhN2U2YjgwOGYyNi5qcGd8fHx8fHwzOTN4Mjk0fGh0dHA6Ly93d3cuYWR2ZXJ0cy5pZS9zdGF0aWMvaS93YXRlcm1hcmsucG5nfHx8.jpg">
                 <meta property="og:description" content="Lego General Zod Minifigure Brand New, New Lego &amp; Building Toys For Sale in Tralee, Kerry, Ireland for 6.00 euros on Adverts.ie.">
                 <meta property="twitter:card" content="product">
                 <meta property="twitter:site" content="@adverts_ie">


### PR DESCRIPTION
This should fix images extraction on theguardian.com

It's good to keep in mind that URLs up to 2000 characters are commonly considered valid.