### PR TITLE
Feature crawler keep paragraphs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.clojars.smallrivers</groupId>
     <artifactId>snacktory</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Snacktory</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j.version>1.7.21</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
     </properties>
     
     <dependencies>        
@@ -26,7 +25,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.10.2</version>
+            <version>1.10.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -49,13 +48,10 @@
             <scope>runtime</scope>
         </dependency>
         
-        <!-- use 1.2.14 instead of 1.2.16 because of
-            java.lang.NullPointerException         at org.apache.log4j.helpers.ISO8601DateFormat.format(ISO8601DateFormat.java:70)
-            -->
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
+            <version>1.2.17</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -132,11 +132,6 @@ public class ArticleTextExtractor {
         this.formatter = formatter;
     }
 
-    /**
-     * @param html extracts article text from given html string. wasn't tested
-     * with improper HTML, although jSoup should be able to handle minor stuff.
-     * @returns extracted article, all HTML tags stripped
-     */
     public JResult extractContent(Document doc) throws Exception {
         return extractContent(new JResult(), doc, formatter, true, true, true, 0);
     }
@@ -149,6 +144,11 @@ public class ArticleTextExtractor {
         return extractContent(res, doc, formatter, true, true, true, 0);
     }
 
+    /**
+     * @param html extracts article text from given html string. wasn't tested
+     * with improper HTML, although jSoup should be able to handle minor stuff.
+     * @returns extracted article, all HTML tags stripped
+     */
     public JResult extractContent(String html) throws Exception {
         return extractContent(html, 0);
     }
@@ -292,8 +292,8 @@ public class ArticleTextExtractor {
         }
 
         // init elements and get the one with highest weight (see getWeight for strategy)
-        Collection<Element> nodes = getNodes(doc);
-        Element bestMatchElement = getBestMatchElement(nodes);
+        final Collection<Element> nodes = getNodes(doc);
+        final Element bestMatchElement = getBestMatchElement(nodes);
 
         // do extraction from the best element
         if (bestMatchElement != null) {

--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -921,9 +921,9 @@ public class ArticleTextExtractor {
                 if (child.tagName().equals("p") && ownTextLength > 50)
                     pEls.add(child);
 
-                if (child.className().toLowerCase().equals("caption"))
+                if (child.className().equalsIgnoreCase("caption"))
                     caption = child;
-            } else if (child.tagName().toLowerCase().equals("strong")) {
+            } else if (child.tagName().equalsIgnoreCase("strong")) {
                 weight -= 100;
             }
         }

--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -406,7 +406,7 @@ public class ArticleTextExtractor {
                 }
             }
         }
-        return SHelper.trimAll(title);
+        return title;
     }
 
     protected String extractCanonicalUrl(Document doc) {

--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -406,7 +406,7 @@ public class ArticleTextExtractor {
                 }
             }
         }
-        return title;
+        return SHelper.trimAll(title);
     }
 
     protected String extractCanonicalUrl(Document doc) {

--- a/src/main/java/de/jetwick/snacktory/OutputFormatter.java
+++ b/src/main/java/de/jetwick/snacktory/OutputFormatter.java
@@ -22,31 +22,23 @@ public class OutputFormatter {
 
     public static final int MIN_FIRST_PARAGRAPH_TEXT = 50; // Min size of first paragraph
     public static final int MIN_PARAGRAPH_TEXT = 30;       // Min size of any other paragraphs
-    private static final List<String> NODES_TO_REPLACE = Arrays.asList("strong", "b", "i");
     private Pattern unlikelyPattern = Pattern.compile("display\\:none|visibility\\:hidden");
     private final int minFirstParagraphText;
     private final int minParagraphText;
-    private final List<String> nodesToReplace;
     private String nodesToKeepCssSelector = "p, ol, small, blockquote";
     private static final String textListNodesSelector = "div, p, ol, small, blockquote";
 
     public OutputFormatter() {
-        this(MIN_FIRST_PARAGRAPH_TEXT, MIN_PARAGRAPH_TEXT, NODES_TO_REPLACE);
+        this(MIN_FIRST_PARAGRAPH_TEXT, MIN_PARAGRAPH_TEXT);
     }
 
     public OutputFormatter(int minParagraphText) {
-        this(minParagraphText, minParagraphText, NODES_TO_REPLACE);
+        this(minParagraphText, minParagraphText);
     }
 
     public OutputFormatter(int minFirstParagraphText, int minParagraphText) {
-        this(minFirstParagraphText, minParagraphText, NODES_TO_REPLACE);
-    }
-
-    public OutputFormatter(int minFirstParagraphText, int minParagraphText,
-                           List<String> nodesToReplace) {
         this.minFirstParagraphText = minFirstParagraphText;
         this.minParagraphText = minParagraphText;
-        this.nodesToReplace = nodesToReplace;
     }
 
     /**

--- a/src/main/java/de/jetwick/snacktory/OutputFormatter.java
+++ b/src/main/java/de/jetwick/snacktory/OutputFormatter.java
@@ -24,10 +24,11 @@ public class OutputFormatter {
     public static final int MIN_PARAGRAPH_TEXT = 30;       // Min size of any other paragraphs
     private static final List<String> NODES_TO_REPLACE = Arrays.asList("strong", "b", "i");
     private Pattern unlikelyPattern = Pattern.compile("display\\:none|visibility\\:hidden");
-    protected final int minFirstParagraphText;
-    protected final int minParagraphText;
-    protected final List<String> nodesToReplace;
-    protected String nodesToKeepCssSelector = "p, ol";
+    private final int minFirstParagraphText;
+    private final int minParagraphText;
+    private final List<String> nodesToReplace;
+    private String nodesToKeepCssSelector = "p, ol, small, blockquote";
+    private static final String textListNodesSelector = "div, p, ol, small, blockquote";
 
     public OutputFormatter() {
         this(MIN_FIRST_PARAGRAPH_TEXT, MIN_PARAGRAPH_TEXT, NODES_TO_REPLACE);
@@ -41,7 +42,7 @@ public class OutputFormatter {
         this(minFirstParagraphText, minParagraphText, NODES_TO_REPLACE);
     }
 
-    public OutputFormatter(int minFirstParagraphText, int minParagraphText, 
+    public OutputFormatter(int minFirstParagraphText, int minParagraphText,
                            List<String> nodesToReplace) {
         this.minFirstParagraphText = minFirstParagraphText;
         this.minParagraphText = minParagraphText;
@@ -76,28 +77,15 @@ public class OutputFormatter {
             return str;
 
         // no subelements
-        if (str.isEmpty() || (!topNode.text().isEmpty() 
+        if (str.isEmpty() || (!topNode.text().isEmpty()
             && str.length() <= topNode.ownText().length())
             || countOfP == 0 || lowTextRatio){
             str = topNode.text();
         }
 
-        // if jsoup failed to parse the whole html now parse this smaller 
+        // if jsoup failed to parse the whole html now parse this smaller
         // snippet again to avoid html tags disturbing our text:
         return Jsoup.parse(str).text();
-    }
-
-    /**
-     * Takes an element and returns a list of texts extracted from the P tags
-     */
-    public List<String> getTextList(Element topNode) {
-        List<String> texts = new ArrayList<String>();
-        for(Element element : topNode.select(this.nodesToKeepCssSelector)) {
-            if(element.hasText()) {
-                texts.add(element.text());
-            }
-        }
-        return texts;
     }
 
     /**
@@ -130,7 +118,7 @@ public class OutputFormatter {
             }
 
             String text = node2Text(e);
-            if (text.isEmpty() || text.length() < getMinParagraph(paragraphWithTextIndex) 
+            if (text.isEmpty() || text.length() < getMinParagraph(paragraphWithTextIndex)
                 || text.length() > SHelper.countLetters(text) * 2){
                 continue;
             }
@@ -184,9 +172,7 @@ public class OutputFormatter {
 
         String style = e.attr("style");
         String clazz = e.attr("class");
-        if (unlikelyPattern.matcher(style).find() || unlikelyPattern.matcher(clazz).find())
-            return true;
-        return false;
+        return (unlikelyPattern.matcher(style).find() || unlikelyPattern.matcher(clazz).find());
     }
 
     void appendTextSkipHidden(Element e, StringBuilder accum, int indent) {
@@ -200,7 +186,7 @@ public class OutputFormatter {
                 accum.append(txt);
             } else if (child instanceof Element) {
                 Element element = (Element) child;
-                if (accum.length() > 0 && element.isBlock() 
+                if (accum.length() > 0 && element.isBlock()
                     && !lastCharIsWhitespace(accum))
                     accum.append(" ");
                 else if (element.tagName().equals("br"))
@@ -231,7 +217,24 @@ public class OutputFormatter {
     protected String node2Text(Element el) {
         StringBuilder sb = new StringBuilder(200);
         appendTextSkipHidden(el, sb, 0);
-        return sb.toString();
+        return sb.toString().trim();
+    }
+
+    /**
+     * Takes an element and returns a list of texts extracted from the P tags
+     */
+    public List<String> getTextList(Element topNode) {
+        List<String> texts = new ArrayList<String>();
+        for(Element element : topNode.select(textListNodesSelector)) {
+            if("div".equals(element.tagName())) {
+                if(element.children().isEmpty() && element.hasText()) {
+                    texts.add(element.text().trim());
+                }
+            } else if(element.hasText()) {
+                texts.add(element.text().trim());
+            }
+        }
+        return texts;
     }
 
     public OutputFormatter setUnlikelyPattern(String unlikelyPattern) {

--- a/src/main/java/de/jetwick/snacktory/OutputFormatter.java
+++ b/src/main/java/de/jetwick/snacktory/OutputFormatter.java
@@ -228,10 +228,10 @@ public class OutputFormatter {
         for(Element element : topNode.select(textListNodesSelector)) {
             if("div".equals(element.tagName())) {
                 if(element.children().isEmpty() && element.hasText()) {
-                    texts.add(element.text().trim());
+                    texts.add(SHelper.trimAll(element.text()));
                 }
             } else if(element.hasText()) {
-                texts.add(element.text().trim());
+                texts.add(SHelper.trimAll(element.text()));
             }
         }
         return texts;

--- a/src/main/java/de/jetwick/snacktory/SHelper.java
+++ b/src/main/java/de/jetwick/snacktory/SHelper.java
@@ -92,8 +92,8 @@ public class SHelper {
         final StringBuilder sb = new StringBuilder();
         boolean previousSpace = false;
         for (int i = 0; i < str.length(); i++) {
-            char c = str.charAt(i);
-            if (c == ' ' || (int) c == 9 || c == '\n') {
+            final char c = str.charAt(i);
+            if (c == ' ' || c == 9 || c == '\n' || c == 160) {
                 previousSpace = true;
                 continue;
             }

--- a/src/main/java/de/jetwick/snacktory/SHelper.java
+++ b/src/main/java/de/jetwick/snacktory/SHelper.java
@@ -36,6 +36,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import org.jsoup.nodes.Element;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  *
  * @author Peter Karich
@@ -44,6 +46,8 @@ public class SHelper {
 
     public static final String UTF8 = "UTF-8";
     private static final Pattern SPACE = Pattern.compile(" ");
+    // &nbsp;
+    private static final Pattern NON_BREAKING_SPACE = Pattern.compile(String.valueOf((char) 160));
 
     public static String replaceSpaces(String url) {
         if (!url.isEmpty()) {
@@ -67,13 +71,25 @@ public class SHelper {
     }
 
     /**
+     * trim all whitespace characters (&bnsp; included) for the given string.
+     */
+    public static String trimAll(final String str) {
+        if (str == null) {
+            return null;
+        } else {
+            return StringUtils.trim(
+                  NON_BREAKING_SPACE.matcher(str).replaceAll(""));
+        }
+    }
+
+    /**
      * remove more than two spaces or newlines
      */
     public static String innerTrim(String str) {
         if (str.isEmpty())
             return "";
 
-        StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder();
         boolean previousSpace = false;
         for (int i = 0; i < str.length(); i++) {
             char c = str.charAt(i);

--- a/src/main/java/de/jetwick/snacktory/SHelper.java
+++ b/src/main/java/de/jetwick/snacktory/SHelper.java
@@ -78,7 +78,7 @@ public class SHelper {
             return null;
         } else {
             return StringUtils.trim(
-                  NON_BREAKING_SPACE.matcher(str).replaceAll(""));
+                  NON_BREAKING_SPACE.matcher(str).replaceAll(" "));
         }
     }
 

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -349,7 +349,7 @@ public class ArticleTextExtractorTest {
     public void testTechcrunch2() throws Exception {
         // http://techcrunch.com/2010/08/13/gantto-takes-on-microsoft-project-with-web-based-project-management-application/
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("techcrunch2.html")));
-        assertEquals("Gantto Takes On Microsoft Project With Web-Based Project Management Application", article.getTitle());
+        assertEquals("Gantto Takes On Microsoft Project With Web-Based Project Management Application", article.getTitle());
         assertTrue(article.getText(), article.getText().startsWith("Y Combinator-backed Gantto is launching"));
         assertEquals("http://i0.wp.com/tctechcrunch2011.files.wordpress.com/2010/08/gantto.jpg?resize=680%2C680", article.getImageUrl());
         assertEquals("Leena Rao", article.getAuthorName());
@@ -1001,7 +1001,7 @@ public class ArticleTextExtractorTest {
     public void testForbes() throws Exception {
         // http://fortune.com/2015/05/11/rackspaces-support-other-cloud/
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("forbes.html")));
-        assertEquals("Does Rackspace’s future lie in supporting someone else’s cloud?", res.getTitle());
+        assertEquals("Does Rackspace’s future lie in supporting someone else’s cloud?", res.getTitle());
         assertTrue(res.getText(), res.getText().startsWith("Rackspace, a true cloud computing pioneer, is starting to sound like a company that will"));
     }
 

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -71,7 +71,7 @@ public class ArticleTextExtractorTest {
     @Test
     public void testData6() throws Exception {
         JResult res = extractor.extractContent(readFileAsString("test_data/6.html"));
-        assertTrue("data6:" + res.getText(), res.getText().equals("Acting Governor of Balkh province, Atta Mohammad Noor, said that differences between leaders of the National Unity Government (NUG) – namely President Ashraf Ghani and CEO Abdullah Abdullah— have paved the ground for mounting insecurity. To watch the whole news bulletin, click here: Hundreds of worried relatives gathered outside Kabul hospitals on Tuesday desperate for news of loved ones following the deadly suicide bombing earlier in the day."));
+        assertEquals("Acting Governor of Balkh province, Atta Mohammad Noor, said that differences between leaders of the National Unity Government (NUG) – namely President Ashraf Ghani and CEO Abdullah Abdullah— have paved the ground for mounting insecurity. To watch the whole news bulletin, click here: Hundreds of worried relatives gathered outside Kabul hospitals on Tuesday desperate for news of loved ones following the deadly suicide bombing earlier in the day.", res.getText());
     }
 
     @Test
@@ -788,35 +788,35 @@ public class ArticleTextExtractorTest {
 
     @Test
     public void testTextList() throws Exception {
-        JResult res = extractor.extractContent(readFileAsString("test_data/1.html"));
-        String text = res.getText();
-        List<String> textList = res.getTextList();
+        final JResult res = extractor.extractContent(readFileAsString("test_data/1.html"));
+        final String text = res.getText();
+        final List<String> textList = res.getTextList();
         assertEquals(25, textList.size());
         assertTrue(textList.get(0).startsWith(text.substring(0, 15)));
-        assertTrue(textList.get(24).endsWith(text.substring(text.length() - 15, text.length())));
+        assertEquals(textList.get(24), text.substring(text.length() - 87, text.length()));
     }
 
     @Test
     public void testMurraySenateGov() throws Exception {
         // Test http://www.murray.senate.gov/public/index.cfm/newsreleases?ContentRecord_id=28da79eb-bca4-421e-9358-cec1c064def0
         // Was not fully extracted by version 1.2.3
-        JResult res = extractor.extractContent(readFileAsString("test_data/murray_senate_gov.html"));
-        String text = res.getText();
+        final JResult res = extractor.extractContent(readFileAsString("test_data/murray_senate_gov.html"));
+        final String text = res.getText();
         // logger.info("text: " + text);
-        List<String> textList = res.getTextList();
+        final List<String> textList = res.getTextList();
         // logger.info("textList:\n-" + StringUtils.join(textList, "\n-"));
         assertEquals(4, textList.size());
         assertTrue(textList.get(0).startsWith(text.substring(0, 15)));
-        assertTrue(textList.get(3).endsWith(text.substring(text.length() - 15, text.length())));
+        assertEquals(textList.get(3), text.substring(text.length() - 472, text.length()));
     }
 
     @Test
     public void testLeFigaroSport() throws Exception {
         // Test http://sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil/fil-info/ronaldo-ecourte-l-entrainement-700221
-        JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("lefigaro.html")));
-        String text = res.getText();
-        assertThat(res.getText(), startsWith("Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace sur un genou, comme il l’a déjà fait à plusieurs reprises depuis son arrivée au Brésil."));
-        List<String> textList = res.getTextList();
+        final JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("lefigaro.html")));
+        final String text = res.getText();
+        assertThat(text, startsWith("Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace sur un genou, comme il l’a déjà fait à plusieurs reprises depuis son arrivée au Brésil."));
+        final List<String> textList = res.getTextList();
         assertEquals(2, textList.size());
         assertTrue(textList.get(0).startsWith(text.substring(0, 15)));
         assertTrue(textList.get(1).endsWith(text.substring(text.length() - 15, text.length())));

--- a/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
+++ b/src/test/java/de/jetwick/snacktory/ArticleTextExtractorTest.java
@@ -626,7 +626,7 @@ public class ArticleTextExtractorTest {
     public void testWikipedia3() throws Exception {
         // http://en.wikipedia.org/wiki/Muhammad
         JResult article = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("wikipedia_muhammad.html")));
-        assertTrue(article.getText(), article.getText().startsWith("Muhammad (c. 570 – c. 8 June 632);[1] also transliterated as Mohammad, Mohammed, or Muhammed; Arabic: محمد‎, full name: Abū al-Qāsim Muḥammad"));
+        assertTrue(article.getText(), article.getText().startsWith("Muhammad (c. 570 – c. 8 June 632);[1] also transliterated as Mohammad, Mohammed, or Muhammed; Arabic: محمد‎, full name: Abū al-Qāsim Muḥammad"));
     }
 
     @Test
@@ -909,7 +909,7 @@ public class ArticleTextExtractorTest {
         // http://www.entrepreneur.com/article/237402
         JResult res = extractor.extractContent(c.streamToString(getClass().getResourceAsStream("entrepreneur.html")));
         assertEquals("7 Big Changes in the PR Landscape Every Business Should Know About", res.getTitle());
-        assertTrue(res.getText(), res.getText().startsWith("At least three times a week, I get emails from entrepreneurs or small-business owners asking for advice on public relations."));
+        assertTrue(res.getText(), res.getText().startsWith("At least three times a week, I get emails from entrepreneurs or small-business owners asking for advice on public relations."));
         assertEquals("Rebekah Iliff", res.getAuthorName());
         assertEquals("Chief Strategy Officer for AirPR", res.getAuthorDescription());
     }

--- a/src/test/java/de/jetwick/snacktory/OutputFormatterTest.java
+++ b/src/test/java/de/jetwick/snacktory/OutputFormatterTest.java
@@ -16,7 +16,6 @@
 package de.jetwick.snacktory;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -41,7 +40,7 @@ public class OutputFormatterTest {
     @Test
     public void testTextList() {
         OutputFormatter formatter = new OutputFormatter();
-        Document doc = Jsoup.parse("<div><p><p>aa</p></p><p>bb</p><p>cc</p></div>");
-        assertEquals(Arrays.asList("aa", "bb", "cc"), formatter.getTextList(doc));
+        Document doc = Jsoup.parse("<div><p><p>aa</p></p><p>bb</p><p>cc</p><div>dd</div></div>");
+        assertEquals(Arrays.asList("aa", "bb", "cc", "dd"), formatter.getTextList(doc));
     }
 }

--- a/src/test/java/de/jetwick/snacktory/SHelperTest.java
+++ b/src/test/java/de/jetwick/snacktory/SHelperTest.java
@@ -143,4 +143,12 @@ public class SHelperTest {
         assertEquals("2001/11/01", SHelper.completeDate("2001/11"));
         assertEquals("2001/11/02", SHelper.completeDate("2001/11/02"));
     }
+
+    @Test
+    public void testTrimAll() {
+        assertNull(SHelper.trimAll(null));
+        assertEquals("", SHelper.trimAll(" "));
+        assertEquals("abc", SHelper.trimAll(" abc "));
+        assertEquals("abc", SHelper.trimAll("abc" + (char) 160));
+    }
 }

--- a/src/test/java/de/jetwick/snacktory/SHelperTest.java
+++ b/src/test/java/de/jetwick/snacktory/SHelperTest.java
@@ -150,5 +150,6 @@ public class SHelperTest {
         assertEquals("", SHelper.trimAll(" "));
         assertEquals("abc", SHelper.trimAll(" abc "));
         assertEquals("abc", SHelper.trimAll("abc" + (char) 160));
+        assertEquals("abc def", SHelper.trimAll("abc" + (char) 160 + "def"));
     }
 }

--- a/src/test/resources/de/jetwick/snacktory/lefigaro.html
+++ b/src/test/resources/de/jetwick/snacktory/lefigaro.html
@@ -1,803 +1,162 @@
-<!doctype html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://opengraphprotocol.org/schema/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fp="http://plus.lefigaro.fr/fp/elements/1.0/" version="XHTML+RDFa 1.0" lang="fr">
-	<head>
-		<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=9" />    
-    
-                    
-    
+                                                                            
+                                                                                                                            <!DOCTYPE HTML PUBLIC>
+        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://opengraphprotocol.org/schema/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fp="http://plus.lefigaro.fr/fp/elements/1.0/" version="XHTML+RDFa 1.0" lang="fr_FR">
+        <head>
+                            <link rel="dns-prefetch" href="http://a.f1g.fr" />
+                            <link rel="dns-prefetch" href="http://i.f1g.fr" />
+                            <link rel="dns-prefetch" href="http://p.f1g.fr" />
+                            <link rel="dns-prefetch" href="http://acdn.adnxs.com" />
+                            <link rel="dns-prefetch" href="http://a.visualrevenue.com" />
+                            <link rel="dns-prefetch" href="http://p.visualrevenue.com" />
+                            <link rel="dns-prefetch" href="http://t1.visualrevenue.com" />
+                            <link rel="dns-prefetch" href="http://lpm-lefigaro.visualrevenue.com" />
+                            <link rel="dns-prefetch" href="http://cdn.krxd.net" />
+                            <link rel="dns-prefetch" href="http://js.antvoice.com" />
+                            <link rel="dns-prefetch" href="http://widgets.outbrain.com" />
+                            <link rel="dns-prefetch" href="http://connect.facebook.com" />
+                            <link rel="dns-prefetch" href="http://lpm-lefigaro.nuggad.net" />
+                            <link rel="dns-prefetch" href="http://plus.lefigaro.fr" />
+                            <link rel="dns-prefetch" href="http://beacon.krxd.net" />
+                            <link rel="dns-prefetch" href="http://logc111.xiti.com" />
+                            <link rel="dns-prefetch" href="http://www.google-analytics.com" />
             
-                                                                                                                                                                                                                                        
-    
-                
-    
-                                <title>Ronaldo écourte l'entraînement - Fil info - 2014-Brésil - Coupe du monde - Football -</title>
-            <!--<meta http-equiv="refresh" content="240" />-->
+                            <meta charset="utf-8"><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={xpid:"VQYPWFNVDRABVVVaBwgGUg=="};window.NREUM||(NREUM={}),__nr_require=function(t,n,e){function r(e){if(!n[e]){var o=n[e]={exports:{}};t[e][0].call(o.exports,function(n){var o=t[e][1][n];return r(o||n)},o,o.exports)}return n[e].exports}if("function"==typeof __nr_require)return __nr_require;for(var o=0;o<e.length;o++)r(e[o]);return r}({1:[function(t,n,e){function r(t){try{s.console&&console.log(t)}catch(n){}}var o,i=t("ee"),a=t(15),s={};try{o=localStorage.getItem("__nr_flags").split(","),console&&"function"==typeof console.log&&(s.console=!0,o.indexOf("dev")!==-1&&(s.dev=!0),o.indexOf("nr_dev")!==-1&&(s.nrDev=!0))}catch(c){}s.nrDev&&i.on("internal-error",function(t){r(t.stack)}),s.dev&&i.on("fn-err",function(t,n,e){r(e.stack)}),s.dev&&(r("NR AGENT IN DEVELOPMENT MODE"),r("flags: "+a(s,function(t,n){return t}).join(", ")))},{}],2:[function(t,n,e){function r(t,n,e,r,o){try{d?d-=1:i("err",[o||new UncaughtException(t,n,e)])}catch(s){try{i("ierr",[s,c.now(),!0])}catch(u){}}return"function"==typeof f&&f.apply(this,a(arguments))}function UncaughtException(t,n,e){this.message=t||"Uncaught error with no additional information",this.sourceURL=n,this.line=e}function o(t){i("err",[t,c.now()])}var i=t("handle"),a=t(16),s=t("ee"),c=t("loader"),f=window.onerror,u=!1,d=0;c.features.err=!0,t(1),window.onerror=r;try{throw new Error}catch(l){"stack"in l&&(t(8),t(7),"addEventListener"in window&&t(5),c.xhrWrappable&&t(9),u=!0)}s.on("fn-start",function(t,n,e){u&&(d+=1)}),s.on("fn-err",function(t,n,e){u&&(this.thrown=!0,o(e))}),s.on("fn-end",function(){u&&!this.thrown&&d>0&&(d-=1)}),s.on("internal-error",function(t){i("ierr",[t,c.now(),!0])})},{}],3:[function(t,n,e){t("loader").features.ins=!0},{}],4:[function(t,n,e){function r(t){}if(window.performance&&window.performance.timing&&window.performance.getEntriesByType){var o=t("ee"),i=t("handle"),a=t(8),s=t(7),c="learResourceTimings",f="addEventListener",u="resourcetimingbufferfull",d="bstResource",l="resource",p="-start",h="-end",m="fn"+p,w="fn"+h,v="bstTimer",y="pushState",g=t("loader");g.features.stn=!0,t(6);var b=NREUM.o.EV;o.on(m,function(t,n){var e=t[0];e instanceof b&&(this.bstStart=g.now())}),o.on(w,function(t,n){var e=t[0];e instanceof b&&i("bst",[e,n,this.bstStart,g.now()])}),a.on(m,function(t,n,e){this.bstStart=g.now(),this.bstType=e}),a.on(w,function(t,n){i(v,[n,this.bstStart,g.now(),this.bstType])}),s.on(m,function(){this.bstStart=g.now()}),s.on(w,function(t,n){i(v,[n,this.bstStart,g.now(),"requestAnimationFrame"])}),o.on(y+p,function(t){this.time=g.now(),this.startPath=location.pathname+location.hash}),o.on(y+h,function(t){i("bstHist",[location.pathname+location.hash,this.startPath,this.time])}),f in window.performance&&(window.performance["c"+c]?window.performance[f](u,function(t){i(d,[window.performance.getEntriesByType(l)]),window.performance["c"+c]()},!1):window.performance[f]("webkit"+u,function(t){i(d,[window.performance.getEntriesByType(l)]),window.performance["webkitC"+c]()},!1)),document[f]("scroll",r,{passive:!0}),document[f]("keypress",r,!1),document[f]("click",r,!1)}},{}],5:[function(t,n,e){function r(t){for(var n=t;n&&!n.hasOwnProperty(u);)n=Object.getPrototypeOf(n);n&&o(n)}function o(t){s.inPlace(t,[u,d],"-",i)}function i(t,n){return t[1]}var a=t("ee").get("events"),s=t(18)(a,!0),c=t("gos"),f=XMLHttpRequest,u="addEventListener",d="removeEventListener";n.exports=a,"getPrototypeOf"in Object?(r(document),r(window),r(f.prototype)):f.prototype.hasOwnProperty(u)&&(o(window),o(f.prototype)),a.on(u+"-start",function(t,n){var e=t[1],r=c(e,"nr@wrapped",function(){function t(){if("function"==typeof e.handleEvent)return e.handleEvent.apply(e,arguments)}var n={object:t,"function":e}[typeof e];return n?s(n,"fn-",null,n.name||"anonymous"):e});this.wrapped=t[1]=r}),a.on(d+"-start",function(t){t[1]=this.wrapped||t[1]})},{}],6:[function(t,n,e){var r=t("ee").get("history"),o=t(18)(r);n.exports=r,o.inPlace(window.history,["pushState","replaceState"],"-")},{}],7:[function(t,n,e){var r=t("ee").get("raf"),o=t(18)(r),i="equestAnimationFrame";n.exports=r,o.inPlace(window,["r"+i,"mozR"+i,"webkitR"+i,"msR"+i],"raf-"),r.on("raf-start",function(t){t[0]=o(t[0],"fn-")})},{}],8:[function(t,n,e){function r(t,n,e){t[0]=a(t[0],"fn-",null,e)}function o(t,n,e){this.method=e,this.timerDuration="number"==typeof t[1]?t[1]:0,t[0]=a(t[0],"fn-",this,e)}var i=t("ee").get("timer"),a=t(18)(i),s="setTimeout",c="setInterval",f="clearTimeout",u="-start",d="-";n.exports=i,a.inPlace(window,[s,"setImmediate"],s+d),a.inPlace(window,[c],c+d),a.inPlace(window,[f,"clearImmediate"],f+d),i.on(c+u,r),i.on(s+u,o)},{}],9:[function(t,n,e){function r(t,n){d.inPlace(n,["onreadystatechange"],"fn-",s)}function o(){var t=this,n=u.context(t);t.readyState>3&&!n.resolved&&(n.resolved=!0,u.emit("xhr-resolved",[],t)),d.inPlace(t,w,"fn-",s)}function i(t){v.push(t),h&&(g=-g,b.data=g)}function a(){for(var t=0;t<v.length;t++)r([],v[t]);v.length&&(v=[])}function s(t,n){return n}function c(t,n){for(var e in t)n[e]=t[e];return n}t(5);var f=t("ee"),u=f.get("xhr"),d=t(18)(u),l=NREUM.o,p=l.XHR,h=l.MO,m="readystatechange",w=["onload","onerror","onabort","onloadstart","onloadend","onprogress","ontimeout"],v=[];n.exports=u;var y=window.XMLHttpRequest=function(t){var n=new p(t);try{u.emit("new-xhr",[n],n),n.addEventListener(m,o,!1)}catch(e){try{u.emit("internal-error",[e])}catch(r){}}return n};if(c(p,y),y.prototype=p.prototype,d.inPlace(y.prototype,["open","send"],"-xhr-",s),u.on("send-xhr-start",function(t,n){r(t,n),i(n)}),u.on("open-xhr-start",r),h){var g=1,b=document.createTextNode(g);new h(a).observe(b,{characterData:!0})}else f.on("fn-end",function(t){t[0]&&t[0].type===m||a()})},{}],10:[function(t,n,e){function r(t){var n=this.params,e=this.metrics;if(!this.ended){this.ended=!0;for(var r=0;r<d;r++)t.removeEventListener(u[r],this.listener,!1);if(!n.aborted){if(e.duration=a.now()-this.startTime,4===t.readyState){n.status=t.status;var i=o(t,this.lastSize);if(i&&(e.rxSize=i),this.sameOrigin){var c=t.getResponseHeader("X-NewRelic-App-Data");c&&(n.cat=c.split(", ").pop())}}else n.status=0;e.cbTime=this.cbTime,f.emit("xhr-done",[t],t),s("xhr",[n,e,this.startTime])}}}function o(t,n){var e=t.responseType;if("json"===e&&null!==n)return n;var r="arraybuffer"===e||"blob"===e||"json"===e?t.response:t.responseText;return h(r)}function i(t,n){var e=c(n),r=t.params;r.host=e.hostname+":"+e.port,r.pathname=e.pathname,t.sameOrigin=e.sameOrigin}var a=t("loader");if(a.xhrWrappable){var s=t("handle"),c=t(11),f=t("ee"),u=["load","error","abort","timeout"],d=u.length,l=t("id"),p=t(14),h=t(13),m=window.XMLHttpRequest;a.features.xhr=!0,t(9),f.on("new-xhr",function(t){var n=this;n.totalCbs=0,n.called=0,n.cbTime=0,n.end=r,n.ended=!1,n.xhrGuids={},n.lastSize=null,p&&(p>34||p<10)||window.opera||t.addEventListener("progress",function(t){n.lastSize=t.loaded},!1)}),f.on("open-xhr-start",function(t){this.params={method:t[0]},i(this,t[1]),this.metrics={}}),f.on("open-xhr-end",function(t,n){"loader_config"in NREUM&&"xpid"in NREUM.loader_config&&this.sameOrigin&&n.setRequestHeader("X-NewRelic-ID",NREUM.loader_config.xpid)}),f.on("send-xhr-start",function(t,n){var e=this.metrics,r=t[0],o=this;if(e&&r){var i=h(r);i&&(e.txSize=i)}this.startTime=a.now(),this.listener=function(t){try{"abort"===t.type&&(o.params.aborted=!0),("load"!==t.type||o.called===o.totalCbs&&(o.onloadCalled||"function"!=typeof n.onload))&&o.end(n)}catch(e){try{f.emit("internal-error",[e])}catch(r){}}};for(var s=0;s<d;s++)n.addEventListener(u[s],this.listener,!1)}),f.on("xhr-cb-time",function(t,n,e){this.cbTime+=t,n?this.onloadCalled=!0:this.called+=1,this.called!==this.totalCbs||!this.onloadCalled&&"function"==typeof e.onload||this.end(e)}),f.on("xhr-load-added",function(t,n){var e=""+l(t)+!!n;this.xhrGuids&&!this.xhrGuids[e]&&(this.xhrGuids[e]=!0,this.totalCbs+=1)}),f.on("xhr-load-removed",function(t,n){var e=""+l(t)+!!n;this.xhrGuids&&this.xhrGuids[e]&&(delete this.xhrGuids[e],this.totalCbs-=1)}),f.on("addEventListener-end",function(t,n){n instanceof m&&"load"===t[0]&&f.emit("xhr-load-added",[t[1],t[2]],n)}),f.on("removeEventListener-end",function(t,n){n instanceof m&&"load"===t[0]&&f.emit("xhr-load-removed",[t[1],t[2]],n)}),f.on("fn-start",function(t,n,e){n instanceof m&&("onload"===e&&(this.onload=!0),("load"===(t[0]&&t[0].type)||this.onload)&&(this.xhrCbStart=a.now()))}),f.on("fn-end",function(t,n){this.xhrCbStart&&f.emit("xhr-cb-time",[a.now()-this.xhrCbStart,this.onload,n],n)})}},{}],11:[function(t,n,e){n.exports=function(t){var n=document.createElement("a"),e=window.location,r={};n.href=t,r.port=n.port;var o=n.href.split("://");!r.port&&o[1]&&(r.port=o[1].split("/")[0].split("@").pop().split(":")[1]),r.port&&"0"!==r.port||(r.port="https"===o[0]?"443":"80"),r.hostname=n.hostname||e.hostname,r.pathname=n.pathname,r.protocol=o[0],"/"!==r.pathname.charAt(0)&&(r.pathname="/"+r.pathname);var i=!n.protocol||":"===n.protocol||n.protocol===e.protocol,a=n.hostname===document.domain&&n.port===e.port;return r.sameOrigin=i&&(!n.hostname||a),r}},{}],12:[function(t,n,e){function r(){}function o(t,n,e){return function(){return i(t,[f.now()].concat(s(arguments)),n?null:this,e),n?void 0:this}}var i=t("handle"),a=t(15),s=t(16),c=t("ee").get("tracer"),f=t("loader"),u=NREUM;"undefined"==typeof window.newrelic&&(newrelic=u);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],l="api-",p=l+"ixn-";a(d,function(t,n){u[n]=o(l+n,!0,"api")}),u.addPageAction=o(l+"addPageAction",!0),u.setCurrentRouteName=o(l+"routeName",!0),n.exports=newrelic,u.interaction=function(){return(new r).get()};var h=r.prototype={createTracer:function(t,n){var e={},r=this,o="function"==typeof n;return i(p+"tracer",[f.now(),t,e],r),function(){if(c.emit((o?"":"no-")+"fn-start",[f.now(),r,o],e),o)try{return n.apply(this,arguments)}finally{c.emit("fn-end",[f.now()],e)}}}};a("setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(t,n){h[n]=o(p+n)}),newrelic.noticeError=function(t){"string"==typeof t&&(t=new Error(t)),i("err",[t,f.now()])}},{}],13:[function(t,n,e){n.exports=function(t){if("string"==typeof t&&t.length)return t.length;if("object"==typeof t){if("undefined"!=typeof ArrayBuffer&&t instanceof ArrayBuffer&&t.byteLength)return t.byteLength;if("undefined"!=typeof Blob&&t instanceof Blob&&t.size)return t.size;if(!("undefined"!=typeof FormData&&t instanceof FormData))try{return JSON.stringify(t).length}catch(n){return}}}},{}],14:[function(t,n,e){var r=0,o=navigator.userAgent.match(/Firefox[\/\s](\d+\.\d+)/);o&&(r=+o[1]),n.exports=r},{}],15:[function(t,n,e){function r(t,n){var e=[],r="",i=0;for(r in t)o.call(t,r)&&(e[i]=n(r,t[r]),i+=1);return e}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],16:[function(t,n,e){function r(t,n,e){n||(n=0),"undefined"==typeof e&&(e=t?t.length:0);for(var r=-1,o=e-n||0,i=Array(o<0?0:o);++r<o;)i[r]=t[n+r];return i}n.exports=r},{}],17:[function(t,n,e){n.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],18:[function(t,n,e){function r(t){return!(t&&t instanceof Function&&t.apply&&!t[a])}var o=t("ee"),i=t(16),a="nr@original",s=Object.prototype.hasOwnProperty,c=!1;n.exports=function(t,n){function e(t,n,e,o){function nrWrapper(){var r,a,s,c;try{a=this,r=i(arguments),s="function"==typeof e?e(r,a):e||{}}catch(f){l([f,"",[r,a,o],s])}u(n+"start",[r,a,o],s);try{return c=t.apply(a,r)}catch(d){throw u(n+"err",[r,a,d],s),d}finally{u(n+"end",[r,a,c],s)}}return r(t)?t:(n||(n=""),nrWrapper[a]=t,d(t,nrWrapper),nrWrapper)}function f(t,n,o,i){o||(o="");var a,s,c,f="-"===o.charAt(0);for(c=0;c<n.length;c++)s=n[c],a=t[s],r(a)||(t[s]=e(a,f?s+o:o,i,s))}function u(e,r,o){if(!c||n){var i=c;c=!0;try{t.emit(e,r,o,n)}catch(a){l([a,e,r,o])}c=i}}function d(t,n){if(Object.defineProperty&&Object.keys)try{var e=Object.keys(t);return e.forEach(function(e){Object.defineProperty(n,e,{get:function(){return t[e]},set:function(n){return t[e]=n,n}})}),n}catch(r){l([r])}for(var o in t)s.call(t,o)&&(n[o]=t[o]);return n}function l(n){try{t.emit("internal-error",n)}catch(e){}}return t||(t=o),e.inPlace=f,e.flag=a,e}},{}],ee:[function(t,n,e){function r(){}function o(t){function n(t){return t&&t instanceof r?t:t?c(t,s,i):i()}function e(e,r,o,i){if(!l.aborted||i){t&&t(e,r,o);for(var a=n(o),s=h(e),c=s.length,f=0;f<c;f++)s[f].apply(a,r);var d=u[y[e]];return d&&d.push([g,e,r,a]),a}}function p(t,n){v[t]=h(t).concat(n)}function h(t){return v[t]||[]}function m(t){return d[t]=d[t]||o(e)}function w(t,n){f(t,function(t,e){n=n||"feature",y[e]=n,n in u||(u[n]=[])})}var v={},y={},g={on:p,emit:e,get:m,listeners:h,context:n,buffer:w,abort:a,aborted:!1};return g}function i(){return new r}function a(){(u.api||u.feature)&&(l.aborted=!0,u=l.backlog={})}var s="nr@context",c=t("gos"),f=t(15),u={},d={},l=n.exports=o();l.backlog=u},{}],gos:[function(t,n,e){function r(t,n,e){if(o.call(t,n))return t[n];var r=e();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(t,n,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return t[n]=r,r}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(t,n,e){function r(t,n,e,r){o.buffer([t],r),o.emit(t,n,e)}var o=t("ee").get("handle");n.exports=r,r.ee=o},{}],id:[function(t,n,e){function r(t){var n=typeof t;return!t||"object"!==n&&"function"!==n?-1:t===window?0:a(t,i,function(){return o++})}var o=1,i="nr@id",a=t("gos");n.exports=r},{}],loader:[function(t,n,e){function r(){if(!x++){var t=b.info=NREUM.info,n=l.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(t&&t.licenseKey&&t.applicationID&&n))return u.abort();f(y,function(n,e){t[n]||(t[n]=e)}),c("mark",["onload",a()+b.offset],null,"api");var e=l.createElement("script");e.src="https://"+t.agent,n.parentNode.insertBefore(e,n)}}function o(){"complete"===l.readyState&&i()}function i(){c("mark",["domContent",a()+b.offset],null,"api")}function a(){return E.exists&&performance.now?Math.round(performance.now()):(s=Math.max((new Date).getTime(),s))-b.offset}var s=(new Date).getTime(),c=t("handle"),f=t(15),u=t("ee"),d=window,l=d.document,p="addEventListener",h="attachEvent",m=d.XMLHttpRequest,w=m&&m.prototype;NREUM.o={ST:setTimeout,CT:clearTimeout,XHR:m,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var v=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1026.min.js"},g=m&&w&&w[p]&&!/CriOS/.test(navigator.userAgent),b=n.exports={offset:s,now:a,origin:v,features:{},xhrWrappable:g};t(12),l[p]?(l[p]("DOMContentLoaded",i,!1),d[p]("load",r,!1)):(l[h]("onreadystatechange",o),d[h]("onload",r)),c("mark",["firstbyte",s],null,"api");var x=0,E=t(17)},{}]},{},["loader",2,10,4,3]);</script>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1,user-scalable=no"/>
+
+<link rel="apple-touch-icon" sizes="57x57" href="/bundles/sport24site/img/favicons/apple-touch-icon-57x57.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="60x60" href="/bundles/sport24site/img/favicons/apple-touch-icon-60x60.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="72x72" href="/bundles/sport24site/img/favicons/apple-touch-icon-72x72.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="76x76" href="/bundles/sport24site/img/favicons/apple-touch-icon-76x76.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="114x114" href="/bundles/sport24site/img/favicons/apple-touch-icon-114x114.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="120x120" href="/bundles/sport24site/img/favicons/apple-touch-icon-120x120.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="144x144" href="/bundles/sport24site/img/favicons/apple-touch-icon-144x144.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="152x152" href="/bundles/sport24site/img/favicons/apple-touch-icon-152x152.png?v=Lefigaro">
+<link rel="apple-touch-icon" sizes="180x180" href="/bundles/sport24site/img/favicons/apple-touch-icon-180x180.png?v=Lefigaro">
+<link rel="icon" type="image/png" href="/bundles/sport24site/img/favicons/favicon-32x32.png?v=Lefigaro" sizes="32x32">
+<link rel="icon" type="image/png" href="/bundles/sport24site/img/favicons/favicon-194x194.png?v=Lefigaro" sizes="194x194">
+<link rel="icon" type="image/png" href="/bundles/sport24site/img/favicons/favicon-96x96.png?v=Lefigaro" sizes="96x96">
+<link rel="icon" type="image/png" href="/bundles/sport24site/img/favicons/android-chrome-192x192.png?v=Lefigaro" sizes="192x192">
+<link rel="icon" type="image/png" href="/bundles/sport24site/img/favicons/favicon-16x16.png?v=Lefigaro" sizes="16x16">
+<link rel="manifest" href="/bundles/sport24site/img/favicons/manifest.json?v=Lefigaro">
+<link rel="mask-icon" href="/bundles/sport24site/img/favicons/safari-pinned-tab.svg?v=Lefigaro" color="#383538">
+<link rel="shortcut icon" href="/bundles/sport24site/img/favicons/favicon.ico?v=Lefigaro">
+<meta name="apple-mobile-web-app-title" content="Sport24">
+<meta name="application-name" content="Sport24">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="msapplication-TileImage" content="/bundles/sport24site/img/favicons/mstile-144x144.png?v=Lefigaro') }}">
+<meta name="msapplication-config" content="/bundles/sport24site/img/favicons/browserconfig.xml?v=Lefigaro') }}">
+<meta name="theme-color" content="#383538">
+
+                                                                            
+                                    
+                                    
+                                    
+        <title>Ronaldo écourte l'entraînement - Fil info - 2014-Brésil - Coupe du monde - Football</title>
+                    <link rel="alternate" href="android-app://com.sport24.android/http/figaro.fr/article/822050"/>
             <meta name="keywords" content="ligue 1, ligue 2, premier league, calcio, liga, bundesliga, ligue des champions, champions league, europa league, euro, coupe du monde, coupe des confédérations, ballon d'or, uefa, coupe de France, équipe de France , Ronaldo écourte l'entraînement" />
-            <meta name="description" content="Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace s..." />
-                    		<link rel="stylesheet" type="text/css" href="/extension/ezfind/design/standard/stylesheets/ezfind.css" />
-<link rel="stylesheet" type="text/css" href="/extension/ezfind/design/standard/stylesheets/ezajax_autocomplete.css" />
-<link rel="stylesheet" type="text/css" href="/extension/sport24/design/site/stylesheets/grid_and_reset.css" />
-<link rel="stylesheet" type="text/css" href="/extension/sport24/design/site/stylesheets/main.css" />
-<link rel="stylesheet" type="text/css" href="/extension/sport24/design/site/stylesheets/style.css" />
+            <meta name="description" content="
+Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace sur un genou, comme il l’a déjà fait à plusieurs reprises depuis son arrivée au Brésil.Les statistiques du Portugal en Coupe du monde :&amp;lt;iframe src=&quot;http://sport24.lefigaro.fr/foot-center/coupe-du-monde/embed.html#/nation/portugal/historique/parcours&quot; frameborder=&quot;0&quot; width=&quot;500&quot; height=&quot;421&quot;&amp;gt;&amp;lt;/iframe&amp;gt; 
+" />
+            <meta name="twitter:card" content="summary">
+            <meta name="twitter:site" content="@Sport24Team">
+            <meta property="og:title" content="Ronaldo écourte l&#039;entraînement - Fil info - 2014-Brésil - Coupe du monde - Football" />
+            <meta property="og:url" content="http://sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil/fil-info/ronaldo-ecourte-l-entrainement-700221" />
+            <meta property="og:site_name" content="Sport24" />
+            <meta property="og:site_locale" content="fr_FR" />
+            <meta property="og:type" content="article" />
+            <meta name="vr:type" content="news" />
+            <meta property="vr:published_time" content="2014/06/18" />
+                            <meta name="vr:category" content="Football, 2014-Brésil" />
+                        <meta name="vr:content_id" content="822050" />
+                        <meta property="og:description" content="
+Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace sur un genou, comme il l’a déjà fait à plusieurs reprises depuis son arrivée au Brésil.Les statistiques du Portugal en Coupe du monde :&amp;lt;iframe src=&quot;http://sport24.lefigaro.fr/foot-center/coupe-du-monde/embed.html#/nation/portugal/historique/parcours&quot; frameborder=&quot;0&quot; width=&quot;500&quot; height=&quot;421&quot;&amp;gt;&amp;lt;/iframe&amp;gt; 
+" />
+            <meta property="article:published_time" content="2014/06/18" />
+            <meta property="article:modified_time" content="2014/06/18" />
+                            <meta property="og:count" content="0"/>
+                <meta property="fp:type" content="article"/>
+                <meta property="fp:remote_id" content="822050"/>
+                <meta property="fp:opencomment" content="TRUE"/>
+                <meta property="fp:app_id" content="b08ec77d4664cdf772c552b3c1d45521"/>
+                <meta property="dc:title" content="Ronaldo écourte l&#039;entraînement - Fil info - 2014-Brésil - Coupe du monde - Football" />
+                                    
+                        <link href="/css/19b891b.css" rel="stylesheet" type="text/css" />
+                <link href="/css/19d9cbc.css" rel="stylesheet" type="text/css" media="print" />
+                    <link rel='stylesheet' href='http://a.f1g.fr/h/assets-components/header-footer/header.css?46' type='text/css' media='all' />
 
-<!--[if IE]>
-<link rel="stylesheet" href="/extension/sport24/design/site/stylesheets/resetcss/css/patches/win-ie-all.css"/>
-<link rel="stylesheet" href="/extension/sport24/design/site/stylesheets/movingboxes-ie.css"/>
-<![endif]-->
-<!--[if IE 7]><link rel="stylesheet" href="/extension/sport24/design/site/stylesheets/resetcss/css/patches/win-ie7.css"/><![endif]-->
-<!--[if lt IE 7]><link rel="stylesheet" href="/extension/sport24/design/site/stylesheets/resetcss/css/patches/win-ie-old.css"/><![endif]-->
-<link href="http://plus.lefigaro.fr/sites/default/modules/fp/fp_user_services/themes/css/fp_auth_api.css"/>
-<link href='/livescore/css/livescore.css'  rel='stylesheet' type='text/css' media='all'/><script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script type="text/javascript" src="/extension/sport24/design/site/javascript/jquery-migrate-1.2.1.min.js"></script>
-<script type="text/javascript">window.jQuery || document.write('<script src="/extension/sport24/design/site/javascript/jquery-1.9.1.min.js"><\/script>')</script>
-<!--[if lte IE 9]>
-<script type="text/javascript" src="/extension/sport24/design/site/javascript/console-polyfill.js"></script>
-<script type="text/javascript" src="/extension/sport24/design/site/javascript/es5-shim.js"></script>
-<![endif]--><script type="text/javascript">
-
-(function($) {
-    var _rootUrl = '/', _serverUrl = _rootUrl + 'ezjscore/', _seperator = '@SEPERATOR$',
-        _prefUrl = _rootUrl + 'user/preferences';
-
-    // FIX: Ajax is broken on IE8 / IE7 on jQuery 1.4.x as it's trying to use the broken window.XMLHttpRequest object
-    if ( window.XMLHttpRequest && window.ActiveXObject )
-        $.ajaxSettings.xhr = function() { try { return new window.ActiveXObject('Microsoft.XMLHTTP'); } catch(e) {} };
-
-    // (static) jQuery.ez() uses jQuery.post() (Or jQuery.get() if post paramer is false)
-    //
-    // @param string callArgs
-    // @param object|array|string|false post Optional post values, uses get request if false or undefined
-    // @param function Optional callBack
-    function _ez( callArgs, post, callBack )
-    {
-        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
-        var url = _serverUrl + 'call/';
-        if ( post )
-        {
-            var _token = '', _tokenNode = document.getElementById('ezxform_token_js');
-            if ( _tokenNode ) _token = _tokenNode.getAttribute('title');
-            if ( post.join !== undefined )// support serializeArray() format
-            {
-                post.push( { 'name': 'ezjscServer_function_arguments', 'value': callArgs } );
-                post.push( { 'name': 'ezxform_token', 'value': _token } );
-            }
-            else if ( typeof(post) === 'string' )// string
-            {
-                post += ( post ? '&' : '' ) + 'ezjscServer_function_arguments=' + callArgs + '&ezxform_token=' + _token;
-            }
-            else // object
-            {
-                post['ezjscServer_function_arguments'] = callArgs;
-                post['ezxform_token'] = _token;
-            }
-            return $.post( url, post, callBack, 'json' );
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/picturefill/2.3.1/picturefill.js"></script>
+<script src="http://a.f1g.fr/h/assets-components/header-footer/header.js?46"></script>
+                                <script>
+    var fpAuthPassport = {
+        'appId': 'b08ec77d4664cdf772c552b3c1d45521',
+        'defautlFormValues': {
+            'data-goto': location.href.url,
+            'data-formlevel': 'light',
+            'data-public': '1',
+            'data-update': '1'
         }
-        return $.get( url + encodeURIComponent( callArgs ), {}, callBack, 'json' );
-    };
-    _ez.url = _serverUrl;
-    _ez.root_url = _rootUrl;
-    _ez.seperator = _seperator;
-    $.ez = _ez;
-
-    $.ez.setPreference = function( name, value )
-    {
-        var param = {'Function': 'set_and_exit', 'Key': name, 'Value': value};
-            _tokenNode = document.getElementById( 'ezxform_token_js' );
-        if ( _tokenNode )
-            param.ezxform_token = _tokenNode.getAttribute( 'title' );
-
-        return $.post( _prefUrl, param );
-    };
-
-    // Method version, for loading response into elements
-    // NB: Does not use json (not possible with .load), so ezjscore/call will return string
-    function _ezLoad( callArgs, post, selector, callBack )
-    {
-        callArgs = callArgs.join !== undefined ? callArgs.join( _seperator ) : callArgs;
-        var url = _serverUrl + 'call/';
-        if ( post )
-        {
-            post['ezjscServer_function_arguments'] = callArgs;
-            post['ezxform_token'] = jQuery('#ezxform_token_js').attr('title');
-        }
-        else
-            url += encodeURIComponent( callArgs );
-
-        return this.load( url + ( selector ? ' ' + selector : '' ), post, callBack );
-    };
-    $.fn.ez = _ezLoad;
-})(jQuery);
-        
+    }
 </script>
-<script type="text/javascript" src="/extension/sport24/design/site/javascript/modernizr-2.0.min.js" charset="utf-8"></script>
-<script type="text/javascript" src="/extension/sport24/design/site/javascript/sport24.js" charset="utf-8"></script>
-<script type="text/javascript" src="/extension/sport24/design/site/javascript/innershiv.js" charset="utf-8"></script>
+<script src="http://p.f1g.fr/sites/default/modules/fp/fp_user_services/scripts/fp_auth.js"></script>
+            
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/waypoints/4.0.0/jquery.waypoints.min.js"></script>
+                <link href="http://sport24.lefigaro.fr/rssfeeds/sport24-football.xml" title="Sport24 : L'actualité en direct" type="application/rss+xml" rel="alternate"/>
 
-<link rel="Shortcut icon" href="/extension/sport24/design/site/images/favicon.ico" type="image/x-icon" />
-<link rel="alternate" type="application/rss+xml" title="Sport24 &ndash; Toute l'actualité" href="http://sport24.lefigaro.fr/rssfeeds/sport24-accueil.xml" />        
-        
-            <script class="kxct" data-id="JKtjq-Dt" data-timing="async" data-version="1.9" type="text/javascript">
-                window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]);
-                (function(){
-                    var k=document.createElement('script');k.type='text/javascript';k.async=true;
-                    var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]);
-                    k.src = /^https?:\/\/([a-z0-9_\-\.]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ? src : src === "disable" ? "" :
-                            (location.protocol==="https:"?"https:":"http:")+"//cdn.krxd.net/controltag?confid=JKtjq-Dt"
-                    ;
-                    var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s);
-                }());
 
+            <script type="text/javascript" src="//a.f1g.fr/datalayer/datalayer-provider.js"></script>
+
+            <script>
+                var dataLayer = [{
+                    BU_siteName:"sport24.com",
+                    BU_environnement:"production",
+                    BU_pageType:"classique",
+                        BU_level1:"Football",
+    BU_level2:"Coupe du monde",
+    BU_level3:"2014-Brésil",
+                    BU_author:"La rédaction",
+                    BU_pageCategory:"flash",
+                    BU_idArticle:"822050",
+                    BU_theme:"",
+                    BU_tagName1:"",
+                    BU_tagName2:"",
+                    BU_tagName3:"",
+                    BU_subscriptionContentType:"gratuit",
+                }];
             </script>
-        
-        
-        
-        <script>
-            var fpAuthPassport = {
-                'appId': 'b08ec77d4664cdf772c552b3c1d45521',
-                'defautlFormValues': {
-                    'data-goto': location.href.url,
-                    'data-formlevel': 'light',
-                    // light : Niveau le plus bas. L'internaute saisi son email et son mot de passe, CGU, Opt-ins
-                    // middle : Niveau intermédiaire. Light + Civilité, Nom, Prénom, Date de Naissance, Profession, CP, Pays
-                    // full : Toutes les informations CRM sont requises. Middle + Téléphone, Adresse, Ville
-                    'data-public': '1',
-                    'data-update': '1'
-                }
-            };
-        </script>
-        
-        <script src="http://plus.lefigaro.fr/sites/default/modules/fp/fp_user_services/scripts/fp_auth.js" type="text/javascript"></script>
-        
-        <script type="text/javascript" src="//d.adxcore.com/a/mtag.php?id=106"></script>
-	</head>
-<body>
-	<div id="container">
-        
-        <script type='text/javascript' src='http://a.f1g.fr/h/assets-components/header-footer/header.js?42'></script><link rel='stylesheet' href='http://a.f1g.fr/h/assets-components/header-footer/header.css?42' type='text/css' media='all' />
+
+                            <script>
+                    var jsDataLayer = new DataLayerProvider();
+
+                    jsDataLayer.init({ isPremium: false,
+                        customEvents: true,
+                    });
+
+                    dataLayer.push(jsDataLayer.getDataBU());
+
+                </script>
+            
+
+            <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M89WCH2');</script>
+<!-- End Google Tag Manager -->        </head>
+        <body style="overflow-x: hidden;" itemtype="http://schema.org/WebPage" itemscope>
+
+            <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M89WCH2"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+                            
     
 
-<header id="fig-header" class="figh figh--loading js-figh--has-reader js-figh-cookie" role="banner">
-<div class="figh__container">
-    <div class="figh-nielsen">
-    <ul class="figh-nielsen__list">
-            <li class="figh-nielsen__item">
-            <a  target="_blank" title="lefigaro.fr" href="http://www.lefigaro.fr" alt="lefigaro.fr">
-                <i class="icon-figh-nielsen-home figh-nielsen__home"></i></a>
-        </li>
-                        <li class="figh-nielsen__item"
-            data-id="18547"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Actu" href="http://www.lefigaro.fr/">Actu</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18548"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Economie" href="http://www.lefigaro.fr/economie">Economie</a>
-        </li>
-                                        <li class="figh-nielsen__item"
-            data-id="18550"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Culture" href="http://www.lefigaro.fr/culture">Culture</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18551"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Lifestyle" href="http://www.lefigaro.fr/lifestyle/">Lifestyle</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18552"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Madame" href="http://madame.lefigaro.fr/">Madame</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18553"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Figaro Store" href="http://boutique.lefigaro.fr/#xtor=AD-183">Figaro Store</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18554"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="FigaroTV" href="http://video.lefigaro.fr/">FigaroTV</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18555"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Sant&eacute;" href="http://sante.lefigaro.fr/">Sant&eacute;</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18556"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Etudiant" href="http://etudiant.lefigaro.fr/">Etudiant</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18578"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Figarochic.cn" href="http://www.figarochic.cn/">Figarochic.cn</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18557"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Histoire" href="http://www.lefigaro.fr/histoire/">Histoire</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18558"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Bourse" href="http://bourse.lefigaro.fr/">Bourse</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18559"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Nautisme" href="http://nautisme.lefigaro.fr/">Nautisme</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18560"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Golf" href="http://golf.lefigaro.fr/">Golf</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18561"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="TVmag" href="http://tvmag.lefigaro.fr/">TVmag</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18562"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Scope" href="http://scope.lefigaro.fr">Scope</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18563"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Voyage" href="http://voyage.lefigaro.fr/">Voyage</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18564"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Ench&egrave;res" href="http://encheres.lefigaro.fr/">Ench&egrave;res</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18565"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Vin" href="http://avis-vin.lefigaro.fr/">Vin</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18566"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Evene" href="http://evene.lefigaro.fr/">Evene</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18567"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="M&eacute;t&eacute;o consult" href="http://france.meteoconsult.fr/meteo-france/prevision_meteo_france.php">M&eacute;t&eacute;o consult</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18568"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Le particulier" href="http://www.leparticulier.fr/">Le particulier</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18569"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Cadremploi" href="http://www.cadremploi.fr/">Cadremploi</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18570"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="La chaine m&eacute;t&eacute;o" href="http://france.lachainemeteo.com/meteo-france/previsions-meteo-france-0.php">La chaine m&eacute;t&eacute;o</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18571"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Keljob" href="http://www.keljob.com/">Keljob</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18572"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Kelformation" href="http://www.kelformation.com/">Kelformation</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18573"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Explorimmo" href="http://www.explorimmo.com/">Explorimmo</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18574"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Propri&eacute;t&eacute;s de France" href="http://www.proprietesdefrance.com/">Propri&eacute;t&eacute;s de France</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18575"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Ticketac" href="http://www.ticketac.com/">Ticketac</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18576"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Vodeo" href="http://www.vodeo.tv/">Vodeo</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18577"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Cplussur" href="http://cplussur.lefigaro.fr/">Cplussur</a>
-        </li>
-                            <li class="figh-nielsen__item"
-            data-id="18579"
-            data-track-feature="Nielsen" data-track-action="Click externe" data-track-element="Lien">
-            <a target="_blank" title="Premium" href="http://premium.lefigaro.fr">Premium</a>
-        </li>
-                </ul>
-    <div class="figh-nielsen__scroll">
-        <div class="figh-nielsen__scroll-container">
-            <i class="figh-nielsen__button--left icon-figh-nielsen-left js-nielsen-bar-btn js-nielsen-bar-btn-left js-fig-nielsen__button--inactive"></i>
-            <i class="figh-nielsen__button--right icon-figh-nielsen-right figh-nielsen__button--active js-fig-nielsen__button--active js-nielsen-bar-btn-right"></i>
-        </div>
-    </div>
-    </div>
-    <div id="social-block" class="js-reader-collapsed js-figh-panel figh-social figh-social--collapsed">
-    <div class="figh-social__container js-figh-social__container">
-        <ul class="figh-social__list js-figh-social__list">
-                            <li class="figh-social__item js-figh-social__item"
-                    data-id="3532"
-                    data-track-feature="Suivre"
-                    data-track-element="Link"
-                    data-track-action="Click"
-                    title="Facebook">
-                    <a href="https://www.facebook.com/sport24fr"  target="_blank" title="Facebook">
-                        <i class="figh-social__link-icon fa fa-facebook"
-                           style="background-color: #3b5898"></i>Facebook</a>
-                </li>
-                            <li class="figh-social__item js-figh-social__item"
-                    data-id="3533"
-                    data-track-feature="Suivre"
-                    data-track-element="Link"
-                    data-track-action="Click"
-                    title="Twitter">
-                    <a href="https://twitter.com/sport24team"  target="_blank" title="Twitter">
-                        <i class="figh-social__link-icon fa fa-twitter"
-                           style="background-color: #50abf1"></i>Twitter</a>
-                </li>
-                            <li class="figh-social__item js-figh-social__item"
-                    data-id="3534"
-                    data-track-feature="Suivre"
-                    data-track-element="Link"
-                    data-track-action="Click"
-                    title="Google Plus">
-                    <a href="https://plus.google.com/116212846325909417357/posts"  target="_blank" title="Google Plus">
-                        <i class="figh-social__link-icon fa fa-google-plus"
-                           style="background-color: #df4a32"></i>Google Plus</a>
-                </li>
-                            <li class="figh-social__item js-figh-social__item"
-                    data-id="3536"
-                    data-track-feature="Suivre"
-                    data-track-element="Link"
-                    data-track-action="Click"
-                    title="Newsletter">
-                    <a href="http://sport24.lefigaro.fr/usercomment/newsletters/(type)/1"  title="Newsletter">
-                        <i class="figh-social__link-icon fa fa-envelope"
-                           style="background-color: #000"></i>Newsletter</a>
-                </li>
-                            <li class="figh-social__item js-figh-social__item"
-                    data-id="3535"
-                    data-track-feature="Suivre"
-                    data-track-element="Link"
-                    data-track-action="Click"
-                    title="iOS (iPhone, iPad)">
-                    <a href="https://itunes.apple.com/fr/app/sport24.com-actualite-sportive/id378095281?mt=8"  target="_blank" title="iOS (iPhone, iPad)">
-                        <i class="figh-social__link-icon fa fa-apple"
-                           style="background-color: grey"></i>iOS (iPhone, iPad)</a>
-                </li>
-                            <li class="figh-social__item js-figh-social__item"
-                    data-id="3537"
-                    data-track-feature="Suivre"
-                    data-track-element="Link"
-                    data-track-action="Click"
-                    title="Android">
-                    <a href="https://play.google.com/store/apps/details?id=com.sport24.android&amp;hl=fr_FR"  target="_blank" title="Android">
-                        <i class="figh-social__link-icon fa fa-android"
-                           style="background-color: #90be4e"></i>Android</a>
-                </li>
-                    </ul>
-        <div class="figh-social__scroll js-figh-social__scroll">
-            <div class="figh-social__scroll-container">
-                <i class="figh-social__button--left icon-figh-social-left js-social-bar-btn js-social-bar-btn-left js-fig-social__button--inactive"></i>
-                <i class="figh-social__button--right icon-figh-social-right js-social-bar-btn figh-social__button--active js-fig-social__button--active js-social-bar-btn-right"></i>
-            </div>
-        </div>
-    </div>
-</div>
-    <div class="figh-search js-figh-search-block">
-        <form class="figh-search__container js-figh-search__container" action="http://sport24.lefigaro.fr/Lintegrale" role="search"
-              method="POST">
-            <input class="figh-search__input js-figh-search__input" type="text" placeholder="Rechercher..."
-                   name="search"/>
-                        <button class="figh-search__btn js-figh-search__btn" data-track-element="Submit"
-                    data-track-feature="Recherche" data-track-action="Validation">Rechercher
-            </button>
-        </form>
-    </div>
-    <div class="figh__full full">
-        <div class="figh__left-side figh-menu">
-            <a class="figh-menu-item figh-menu-item--nav js-figh-open-close-nav js-figh-btn-nav"
-               title="Voir les rubriques" data-track-feature="Menu" data-track-element="Burger">
-                <span class="figh-menu-item__container figh-menu-item__container--no-border">
-                    <span class="burger">
-                        <i></i>
-                        <i></i>
-                        <i></i>
-                                                <span class="figh-reader-icon__count js-figh-reader-icon__global-count figh-reader-icon__count--hide"></span>                    </span>
-                    <br/>Menu</span>
-            </a>
-                            <a class="figh-menu-item js-figh-reader" data-track-element="Bouton" data-track-feature="Reader">
-                    <span class="figh-menu-item__container figh-menu-item__container--no-border">
-                        <i class="figh-icon--big icon-figh-endirect">
-                            <span class="figh-reader-icon__count js-figh-reader-icon__global-count figh-reader-icon__count--hide"></span>
-                        </i>
-                        <br/>En ce moment</span>
-                </a>
-                                </div>
-        <div class="figh__right-side figh-menu">
-                            <a class="figh-menu-item js-figh-menu-item__social"
-                        data-track-feature="Suivre" data-track-element="Bouton" >
-                    <i class="fa fa-angle-up"></i>
-                    <span class="figh-menu-item__container figh-menu-item__container--no-border">
-                        <i class="figh-icon--big icon-figh-suivre"></i><br/>Suivre</span>
-                </a>
-                                        <a class="figh-menu-item js-figh-search" data-track-element="Boutton" data-track-feature="Recherche">
-                    <i class="fa fa-angle-up"></i>
-                    <span class="figh-menu-item__container ">
-                        <i class="figh-icon--big icon-figh-recherche" ></i><br/>Recherche</span>
-                </a>
-            
-                        <a class="figh-menu-item figh-connexion js-figh-signin figh-connexion--connecting"
-                data-track-element="Bouton" data-track-feature="Connexion"
-                >
-                <i class="fa fa-angle-up"></i>
-                <span class="figh-menu-item__container">
-                    <i class="figh-icon--big icon-figh-connexion"></i></span>
-            </a>
-            
-        </div>
-        <div class="figh__middle-side middle_side">
-            <div class="figh-logo" role="main">
-                <a href="http://sport24.lefigaro.fr/">
-                    <img class="figh-logo__desktop"
-                         src="//a.f1g.fr/h/assets-components/header-footer/sport-desktop.svg"
-                         alt="Sport"/>
-                    <img class="figh-logo__tablette"
-                         src="//a.f1g.fr/h/assets-components/header-footer/sport-tablette.svg"
-                         alt="Sport"/>
-                    <img class="figh-logo__mobile"
-                         src="//a.f1g.fr/h/assets-components/header-footer/sport-mobile.svg"
-                         alt="Sport"/>
-                </a>
-            </div>
-            <div class="figh-keyword">
-    <ul class="figh-keyword__list">
-                                <li data-id="5224"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link figh-keyword__link--highlighted"
-                   href="http://sport24.lefigaro.fr/livescore"
-                                           title="R&eacute;sultats">
-                    <i class="fa fa-calendar"></i>                     R&eacute;sultats
-                </a>
-            </li>
-                                            <li data-id="5222"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/football"
-                                           title="Football">
-                                        Football
-                </a>
-            </li>
-                                            <li data-id="5227"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/rugby"
-                                           title="Rugby">
-                                        Rugby
-                </a>
-            </li>
-                                            <li data-id="5223"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/tennis"
-                                           title="Tennis">
-                                        Tennis
-                </a>
-            </li>
-                                            <li data-id="5225"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/basket/"
-                                           title="Basket">
-                                        Basket
-                </a>
-            </li>
-                                            <li data-id="5230"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/auto-moto/formule-1"
-                                           title="F1">
-                                        F1
-                </a>
-            </li>
-                                            <li data-id="5231"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://golf.lefigaro.fr/"
-                         target="_blank"                   title="Golf">
-                                        Golf
-                </a>
-            </li>
-                                            <li data-id="5228"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/le-scan-sport"
-                         target="_blank"                   title="Le Scan Sport">
-                                        Le Scan Sport
-                </a>
-            </li>
-                                            <li data-id="5229"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://video.lefigaro.fr/sport24/"
-                                           title="Vid&eacute;os">
-                    <i class="fa fa-youtube-play"></i>                     Vid&eacute;os
-                </a>
-            </li>
-                                            <li data-id="5226"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link"
-                   href="http://sport24.lefigaro.fr/diaporamas"
-                                           title="Diapo">
-                    <i class="fa fa-camera"></i>                     Diapo
-                </a>
-            </li>
-                                            <li data-id="5232"
-                data-track-feature="Keyword"
-                data-track-action="Click"
-                data-track-element="Link"
-                class="figh-keyword__item">
-                <a class="figh-keyword__link figh-keyword__link--highlighted"
-                   href="http://sport24.lefigaro.fr/football/transferts"
-                                           title="Transferts">
-                                        Transferts
-                </a>
-            </li>
-                        </ul>
-    <a class="figh-keyword__link figh-keyword__link--more js-figh-open-close-nav" title="Afficher le menu" data-track-feature="Menu" data-track-Element="Bouton plus" >
-        <i class="icon-figh-plus"></i>
-    </a>
-</div>
-        </div>
-    </div>
-</div>
-<div class="collapsed_content">
-    <a class="btn js-figh-open-close-nav figh-collapse__nav-btn">
-        <i class="burger"><i></i><i></i><i></i></i><span>Menu</span>
-    </a>
-    <div class="figh-collapse__logo">
-        <a href="http://sport24.lefigaro.fr/">
-            <img class="figh-logo--collapse"
-                 src="//a.f1g.fr/h/assets-components/header-footer/sport-collapse.svg"
-                 alt="Sport"/>
-        </a>
-    </div>
-    </div>
-<div id="left-panel" class="figh-left-panel">
-    <div class="mobile-only js-figh-mobile-menu figh-mobile-menu figh-mobile-menu--collapsed">
-        <a class="figh-mobile-menu__item js-figh-mobileburger figh-mobile-menu__item--3" data-track-feature="Menu"
-           data-track-element="Burger">
-            <span class="figh-mobile-menu__item-container">
-                <i class="burger"><i></i><i></i><i></i></i><br/>Menu</span>
-        </a>
-                    <a class="figh-mobile-menu__item js-figh-reader figh-mobile-menu__item--3" data-track-element="Bouton"
-               data-track-feature="Reader">
-                <span class="figh-mobile-menu__item-container">
-                    <i class="figh-icon--big icon-figh-endirect">
-                        <span class="figh-reader-icon__count js-figh-reader-icon__global-count figh-reader-icon__count--hide"></span>
-                    </i>
-                    <br/>En ce moment</span>
-            </a>
-                                <a class="figh-mobile-menu__item figh-connexion js-figh-signin figh-connexion--connecting figh-mobile-menu__item--3 "
-            data-track-element="Bouton" data-track-feature="Connexion"
-            >
-             <span class="figh-mobile-menu__item-container figh-menu-item__container--no-border">
-                <i class="figh-icon--big icon-figh-connexion"></i>
-             </span>
-        </a>
-    </div>
-    <div id="left_menu" class="js-nav-collapsed figh-nav figh-nav--collapsed" data-id="1" data-level="0">
-        <div class="mobile-only figh-mobile-search">
-            <form class="figh-search__container js-figh-search__container" action="http://sport24.lefigaro.fr/Lintegrale" role="search"
-                  method="POST">
-                <input class="figh-search__input js-figh-search__input--mobile" type="text"
-                       placeholder="Rechercher..." name="search"/>
-                
-                <button class="figh-search__btn js-figh-search__btn"
-                        data-track-feature="Recherche" data-track-action="Validation">
-                    <i class="fa fa-search"></i>
-                </button>
-            </form>
-        </div>
-        <nav class="js-figh-treenode-container figh-treenode-container" role="navigation">
-            <ul class="figh-nav__container">
-                    <li data-id="160" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/le-scan-sport" class="figh-nav__expander" title="Le Scan Sport">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/le-scan-sport" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Le Scan Sport</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                            </ul>                    </li>
-                            <li data-id="162" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/football" class="figh-nav__expander" title="Football">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/football" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Football</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                                                                                                    </ul>                    </li>
-                            <li data-id="186" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/tennis" class="figh-nav__expander" title="Tennis">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/tennis" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Tennis</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                            </ul>                    </li>
-                            <li data-id="201" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/rugby" class="figh-nav__expander" title="Rugby">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/rugby" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Rugby</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                                                    </ul>                    </li>
-                            <li data-id="212" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/basket" class="figh-nav__expander" title="Basket">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/basket" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Basket</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                            </ul>                    </li>
-                            <li data-id="221" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/auto-moto" class="figh-nav__expander" title="Auto-Moto">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/auto-moto" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Auto-Moto</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                                                                </ul>                    </li>
-                            <li data-id="1429" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/handball/" class="figh-nav__expander" title="Handball">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/handball/" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Handball</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                            </ul>                    </li>
-                            <li data-id="250" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/voile" class="figh-nav__expander" title="Voile">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/voile" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Voile</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                            </ul>                    </li>
-                            <li data-id="251" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://golf.lefigaro.fr/" class="figh-nav__expander" title="Golf">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://golf.lefigaro.fr/" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Golf</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                                        </ul>                    </li>
-                            <li data-id="238" class="figh-nav__level--3">
-            <div class="links">
-                <span  class="figh-nav__expander" title="Plus de sports">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a class="js-arrow-event" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Plus de sports</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                                                                                                                                        </ul>                    </li>
-                            <li data-id="488" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://video.lefigaro.fr/sport24/" class="figh-nav__expander" title="Vid&eacute;os Sport">
-                                                            <a href="http://video.lefigaro.fr/sport24/" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Vid&eacute;os Sport</a>
-                </span>
-            </div>
-                    </li>
-                            <li data-id="735" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/diaporamas" class="figh-nav__expander" title="Diapo Sport">
-                                                            <a href="http://sport24.lefigaro.fr/diaporamas" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Diapo Sport</a>
-                </span>
-            </div>
-                    </li>
-                            <li data-id="736" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/pages/home_blogs.html" class="figh-nav__expander" title="Blogs Sport">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a href="http://sport24.lefigaro.fr/pages/home_blogs.html" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Blogs Sport</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                                                                </ul>                    </li>
-                            <li data-id="1140" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://tvmag.sport24.lefigaro.fr/programme-tv" class="figh-nav__expander" title="Agenda TV Sport">
-                                                            <a href="http://tvmag.sport24.lefigaro.fr/programme-tv" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Agenda TV Sport</a>
-                </span>
-            </div>
-                    </li>
-                            <li data-id="1462" class="figh-nav__level--3">
-            <div class="links">
-                <span href="http://sport24.lefigaro.fr/paris-sportifs" class="figh-nav__expander" title="Paris sportifs">
-                                                            <a href="http://sport24.lefigaro.fr/paris-sportifs" class="" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Paris sportifs</a>
-                </span>
-            </div>
-                    </li>
-                            <li data-id="1143" class="figh-nav__level--3">
-            <div class="links">
-                <span  class="figh-nav__expander" title="Bons Plans">
-                                        <i class="js-arrow-event icon-figh-plus"></i>                    <a class="js-arrow-event" data-track-feature="Menu" data-track-element="Lien" data-track-action="Click lien">Bons Plans</a>
-                </span>
-            </div>
-                            <ul class="figh-nav__container">
-                            </ul>                    </li>
-            </ul>        </nav>
 
-    </div>
-            <div id="reader-block" class="js-reader-collapsed figh-reader figh-reader--collapsed">
-    <div class="figh-reader__container">
-    </div>
-</div>        <div id="signin-block" class="figh-sign-in js-figh-signin-block mobile-only">
-        <div class="figh-sign-in__container">
-        </div>
-    </div>
-</div>
-<div id="right-panel" class="figh-right-panel figh-logged figh-logged--collapsed">
-    <div class="figh-logged__container">
-        <ul class="figh-user-menu-liste1 figh-logged__list figh-logged__list--bold"></ul>
-        <ul class="figh-user-menu-liste2 figh-logged__list"></ul>
-        <ul class="figh-user-menu-liste3 figh-logged__list"></ul>
-        <ul class="figh-user-menu-liste4 figh-logged__list"></ul>
-    </div>
-</div>
-<div class="header-placeholder"></div>
 <style>
-    #fig-header .figh__full,
+        #fig-header .figh__full,
     #fig-header .collapsed_content,
     .fig-secondary-background,
     #fig-footer {
@@ -818,19 +177,35 @@
 
     .figh__not-ios #fig-header .figh-keyword__item--current a:hover,
     #fig-header .figh-keyword__item--current a:focus,
-    .figh__not-ios #fig-header.figh a:hover, #fig-header.figh a:focus,
+    .figh__not-ios #fig-header .figh__container a:hover,
+    #fig-header .figh__container a:focus,
     .figh__not-ios #fig-header .figh-nav__container a:hover,
     #fig-footer .figh-footer__link:hover {
         color: #ff9900;
     }
 
-    .figh__not-ios #fig-header .figh-menu-item--nav:hover .burger i { border-color: #ff9900; }
+    #fig-header .figh-menu-item {
+        color: #FFFFFF;
+    }
 
-    .figh__not-ios #fig-header .figh-keyword__link--more:hover, #fig-header .figh-keyword__link--more:focus {
+    #fig-header .burger i,
+    #fig-header .burger::before,
+    #fig-header .burger::after {
+        border-top: 1px solid #FFFFFF !important;
+    }
+
+    .figh__not-ios #fig-header .figh-menu-item--nav:hover .burger i,
+    .figh__not-ios #fig-header .figh-menu-item--nav:hover .burger::before,
+    .figh__not-ios #fig-header .figh-menu-item--nav:hover .burger::after
+    { border-color: #ff9900; }
+
+    .figh__not-ios #fig-header .figh-keyword__link--more:hover,
+    #fig-header .figh-keyword__link--more:focus {
         border-color: #ff9900;
     }
 
-    #fig-header .figh-menu-item--nav, #fig-header .figh-collapse__nav-btn {
+    #fig-header .figh-menu-item--nav,
+    #fig-header .figh-collapse__nav-btn {
         background-color: #383538;
     }
 
@@ -839,39 +214,850 @@
         color: #ffffff;
     }
 
-    #fig-header .figh-menu-item__container, #fig-header .figh-menu-item__container,
-    #fig-header .figh-keyword__item--current a, #fig-header .figh-keyword__item {
+    .figh__not-ios #fig-header.figh .figh-keyword__link--highlighted:hover {
+        color: #FFFFFF;
+    }
+
+    #fig-header .figh-menu-item__container,
+    #fig-header .figh-keyword__item--current a,
+    #fig-header .figh-keyword__item {
         border-color: #7d7a7d;
     }
 
-    #fig-header .figh-search__btn, #fig-header button.figh-search__btn, #fig-header .figh-sign-in__btn {
+    #fig-header .figh-search__btn,
+    #fig-header button.figh-search__btn,
+    #fig-header .figh-sign-in__btn {
         background-color: #fc0522;
         color: #ffffff;
     }
 
-    #fig-header .figh-nav__root-node { border-color: #fc0522; }
-
     #fig-footer .figh-footer__item { border-left-color: #7d7a7d; }
+    
+        #fig-header .figh-treenode__item--root-node::before { background-color: #fc0522; }
+    #fig-header .figh-treenode__item--root-node > .figh-treenode__item-wrapper { background-color: #fc0522 !important; }
 </style>
                     
+<header id="fig-header" class="figh figh--loading js-figh--has-reader js-figh-cookie">
+<div class="figh__container">
+    <div class="figh-nielsen figh-nielsen--with-abo">
+    <ul class="figh-nielsen__list">
+            <li class="figh-nielsen__item">
+            <a  target="_blank" title="lefigaro.fr" href="http://www.lefigaro.fr">
+                <i class="figh-icon-nielsen-home figh-nielsen__home"></i>
+            </a>
+        </li>
+                        <li class="figh-nielsen__item"
+            data-id="41949">
+            <a target="_blank" title="Actu" href="http://www.lefigaro.fr/">Actu</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41950">
+            <a target="_blank" title="Economie" href="http://www.lefigaro.fr/economie">Economie</a>
+        </li>
+                                        <li class="figh-nielsen__item"
+            data-id="41952">
+            <a target="_blank" title="Culture" href="http://www.lefigaro.fr/culture">Culture</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41953">
+            <a target="_blank" title="Lifestyle" href="http://www.lefigaro.fr/lifestyle/">Lifestyle</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41954">
+            <a target="_blank" title="Madame" href="http://madame.lefigaro.fr/">Madame</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41955">
+            <a target="_blank" title="Figaro Store" href="http://boutique.lefigaro.fr/#xtor=AD-183">Figaro Store</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41956">
+            <a target="_blank" title="FigaroTV" href="http://video.lefigaro.fr/">FigaroTV</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41957">
+            <a target="_blank" title="Sant&eacute;" href="http://sante.lefigaro.fr/">Sant&eacute;</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41958">
+            <a target="_blank" title="Etudiant" href="http://etudiant.lefigaro.fr/">Etudiant</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41980">
+            <a target="_blank" title="Figarochic.cn" href="http://www.figarochic.cn/">Figarochic.cn</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41959">
+            <a target="_blank" title="Histoire" href="http://www.lefigaro.fr/histoire/">Histoire</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41960">
+            <a target="_blank" title="Bourse" href="http://bourse.lefigaro.fr/">Bourse</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41961">
+            <a target="_blank" title="Nautisme" href="http://nautisme.lefigaro.fr/">Nautisme</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41962">
+            <a target="_blank" title="Golf" href="http://golf.lefigaro.fr/">Golf</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41963">
+            <a target="_blank" title="TVmag" href="http://tvmag.lefigaro.fr/">TVmag</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41964">
+            <a target="_blank" title="Scope" href="http://scope.lefigaro.fr">Scope</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41965">
+            <a target="_blank" title="Voyage" href="http://voyage.lefigaro.fr/">Voyage</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41966">
+            <a target="_blank" title="Ench&egrave;res" href="http://encheres.lefigaro.fr/">Ench&egrave;res</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41967">
+            <a target="_blank" title="Vin" href="http://avis-vin.lefigaro.fr/">Vin</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41968">
+            <a target="_blank" title="Evene" href="http://evene.lefigaro.fr/">Evene</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41969">
+            <a target="_blank" title="M&eacute;t&eacute;o consult" href="http://france.meteoconsult.fr/meteo-france/prevision_meteo_france.php">M&eacute;t&eacute;o consult</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41970">
+            <a target="_blank" title="Le particulier" href="http://www.leparticulier.fr/">Le particulier</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41971">
+            <a target="_blank" title="Cadremploi" href="http://www.cadremploi.fr/">Cadremploi</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41972">
+            <a target="_blank" title="La chaine m&eacute;t&eacute;o" href="http://france.lachainemeteo.com/meteo-france/previsions-meteo-france-0.php">La chaine m&eacute;t&eacute;o</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41973">
+            <a target="_blank" title="Keljob" href="http://www.keljob.com/">Keljob</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41974">
+            <a target="_blank" title="Kelformation" href="http://www.kelformation.com/">Kelformation</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41975">
+            <a target="_blank" title="Explorimmo" href="http://www.explorimmo.com/">Explorimmo</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41976">
+            <a target="_blank" title="Propri&eacute;t&eacute;s de France" href="http://www.proprietesdefrance.com/">Propri&eacute;t&eacute;s de France</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41977">
+            <a target="_blank" title="Ticketac" href="http://www.ticketac.com/">Ticketac</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41978">
+            <a target="_blank" title="Vodeo" href="http://www.vodeo.tv/">Vodeo</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41979">
+            <a target="_blank" title="Cplussur" href="http://cplussur.lefigaro.fr/">Cplussur</a>
+        </li>
+                            <li class="figh-nielsen__item"
+            data-id="41981">
+            <a target="_blank" title="Premium" href="http://premium.lefigaro.fr">Premium</a>
+        </li>
+                </ul>
+    <div class="figh-nielsen__scroll">
+        <div class="figh-nielsen__scroll-container">
+            <i class="figh-nielsen__button--left figh-icon-nielsen-left js-nielsen-bar-btn js-nielsen-bar-btn-left js-fig-nielsen__button--inactive"></i>
+            <i class="figh-nielsen__button--right figh-icon-nielsen-right figh-nielsen__button--active js-fig-nielsen__button--active js-nielsen-bar-btn-right"></i>
+        </div>
+    </div>
+            <div class="figh-abo-container">
+            <span class="figh-abo-logo"></span>
+            <a href="https://boutique.lefigaro.fr/abonnement/premium/offre/payer?origine=VWH16001&xtor=AD-726" class="figh-abo-button">Abonnez-vous</a>
+        </div>
+    </div>
+    <div id="social-block" class="js-reader-collapsed js-figh-panel figh-social figh-social--collapsed">
+    <div class="figh-social__container js-figh-social__container">
+        <ul class="figh-social__list js-figh-social__list">
+                            <li class="figh-social__item js-figh-social__item"
+                    data-id="9446"
+                    title="Facebook">
+                    <a href="https://www.facebook.com/sport24fr"  target="_blank" title="Facebook">
+                        <i class="figh-social__link-icon figh-icon-facebook"
+                           style="background-color: #3b5898"></i>Facebook</a>
+                </li>
+                            <li class="figh-social__item js-figh-social__item"
+                    data-id="9447"
+                    title="Twitter">
+                    <a href="https://twitter.com/sport24team"  target="_blank" title="Twitter">
+                        <i class="figh-social__link-icon figh-icon-twitter"
+                           style="background-color: #50abf1"></i>Twitter</a>
+                </li>
+                            <li class="figh-social__item js-figh-social__item"
+                    data-id="9448"
+                    title="Google Plus">
+                    <a href="https://plus.google.com/116212846325909417357/posts"  target="_blank" title="Google Plus">
+                        <i class="figh-social__link-icon figh-icon-google-plus"
+                           style="background-color: #df4a32"></i>Google Plus</a>
+                </li>
+                            <li class="figh-social__item js-figh-social__item"
+                    data-id="9450"
+                    title="Newsletter">
+                    <a href="/newsletter/manager"  title="Newsletter">
+                        <i class="figh-social__link-icon figh-icon-envelope"
+                           style="background-color: #000"></i>Newsletter</a>
+                </li>
+                            <li class="figh-social__item js-figh-social__item"
+                    data-id="9449"
+                    title="iOS (iPhone, iPad)">
+                    <a href="https://itunes.apple.com/fr/app/sport24.com-actualite-sportive/id378095281?mt=8"  target="_blank" title="iOS (iPhone, iPad)">
+                        <i class="figh-social__link-icon figh-icon-apple"
+                           style="background-color: grey"></i>iOS (iPhone, iPad)</a>
+                </li>
+                            <li class="figh-social__item js-figh-social__item"
+                    data-id="9451"
+                    title="Android">
+                    <a href="https://play.google.com/store/apps/details?id=com.sport24.android&amp;hl=fr_FR"  target="_blank" title="Android">
+                        <i class="figh-social__link-icon figh-icon-android"
+                           style="background-color: #90be4e"></i>Android</a>
+                </li>
+                    </ul>
+        <div class="figh-social__scroll js-figh-social__scroll">
+            <div class="figh-social__scroll-container">
+                <i class="figh-social__button--left figh-icon-nielsen-left js-social-bar-btn js-social-bar-btn-left js-fig-social__button--inactive"></i>
+                <i class="figh-social__button--right figh-icon-nielsen-right js-social-bar-btn figh-social__button--active js-fig-social__button--active js-social-bar-btn-right"></i>
+            </div>
+        </div>
+    </div>
+</div>
+            <div class="figh-search js-figh-search-block">
+            <form class="figh-search__container js-figh-search__container" action="/l-integrale" role="search"
+                  method="GET">
+                <input class="figh-search__input js-figh-search__input" type="text" placeholder="Rechercher..."
+                       name="searchText"/>
+                null                <button class="figh-search__btn js-figh-search__btn">Rechercher</button>
+            </form>
+        </div>
+        <div class="figh__full full">
+        <div class="figh__left-side figh-menu">
+            <a class="figh-menu-item figh-menu-item--nav js-figh-open-close-nav js-figh-btn-nav" title="Voir les rubriques">
+                <span class="figh-menu-item__container figh-menu-item__container--no-border">
+                    <span class="burger">
+                        <i></i>
+                                                <span class="figh-reader-icon__count js-figh-reader-icon__global-count figh-reader-icon__count--hide"></span>                    </span>
+                    <br/>Menu</span>
+            </a>
+                            <a class="figh-menu-item js-figh-reader">
+                    <span class="figh-menu-item__container figh-menu-item__container--no-border">
+                        <i class="figh-icon--big figh-icon-endirect">
+                            <span class="figh-reader-icon__count js-figh-reader-icon__global-count figh-reader-icon__count--hide"></span>
+                        </i>
+                        <br/>En ce moment</span>
+                </a>
+                                </div>
+        <div class="figh__right-side figh-menu">
+                            <a class="figh-menu-item js-figh-menu-item__social">
+                    <i class="figh-icon-angle-up"></i>
+                    <span class="figh-menu-item__container figh-menu-item__container--no-border">
+                        <i class="figh-icon--big figh-icon-suivre"></i><br/>Suivre</span>
+                </a>
+                                        <a class="figh-menu-item js-figh-search">
+                    <i class="figh-icon-angle-up"></i>
+                    <span class="figh-menu-item__container ">
+                        <i class="figh-icon--big figh-icon-recherche" ></i><br/>Recherche</span>
+                </a>
+            
+                        <a class="figh-menu-item figh-connexion js-figh-signin figh-connexion--connecting"
+                >
+                <i class="figh-icon-angle-up"></i>
+                <span class="figh-menu-item__container">
+                    <i class="figh-icon--big figh-icon-connexion"></i></span>
+            </a>
+            
+        </div>
+        <div class="figh__middle-side middle_side">
+            <div class="figh-logo" role="main">
+                <a href="/">
+                    <img class="figh-logo__desktop"
+                         src="//a.f1g.fr/h/assets-components/header-footer/sport-desktop.svg"
+                         alt="Sport"/>
+                    <img class="figh-logo__tablette"
+                         src="//a.f1g.fr/h/assets-components/header-footer/sport-tablette.svg"
+                         alt="Sport"/>
+                    <img class="figh-logo__mobile"
+                         src="//a.f1g.fr/h/assets-components/header-footer/sport-mobile.svg"
+                         alt="Sport"/>
+                </a>
+            </div>
+                 
+    <div class="figh-keyword">
+        <ul class="figh-keyword__list">
+                                            <li data-id="13496"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link figh-keyword__link--highlighted"
+                       href="/livescore"
+                                                                               title="R&eacute;sultats">
+                        <i class="figh-icon-calendar"></i>                         R&eacute;sultats
+                    </a>
+                </li>
+                                                            <li data-id="13494"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/football"
+                                                                               title="Football">
+                                                Football
+                    </a>
+                </li>
+                                                            <li data-id="13498"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/rugby"
+                                                                               title="Rugby">
+                                                Rugby
+                    </a>
+                </li>
+                                                            <li data-id="13495"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link figh-keyword__link--highlighted"
+                       href="/tennis/roland-garros"
+                                                                               title="Tennis">
+                                                Tennis
+                    </a>
+                </li>
+                                                            <li data-id="13503"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/basket"
+                                                                               title="Basket">
+                                                Basket
+                    </a>
+                </li>
+                                                            <li data-id="13504"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/auto-moto/formule-1"
+                                                                               title="F1">
+                                                F1
+                    </a>
+                </li>
+                                                            <li data-id="13501"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/auto-moto"
+                                                                               title="Auto-Moto">
+                                                Auto-Moto
+                    </a>
+                </li>
+                                                            <li data-id="13497"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/cyclisme"
+                                                                               title="Cyclisme">
+                                                Cyclisme
+                    </a>
+                </li>
+                                                            <li data-id="13502"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="/voile"
+                                                                               title="Voile">
+                                                Voile
+                    </a>
+                </li>
+                                                            <li data-id="13500"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link"
+                       href="http://golf.lefigaro.fr/"
+                             target="_blank"                                                   title="Golf">
+                                                Golf
+                    </a>
+                </li>
+                                                            <li data-id="13499"
+                    class="figh-keyword__item">
+                    <a class="figh-keyword__link figh-keyword__link--highlighted"
+                       href="/le-scan-sport"
+                             target="_blank"                                                   title="Le Scan Sport">
+                                                Le Scan Sport
+                    </a>
+                </li>
+                                    </ul>
+        <a class="figh-keyword__link figh-keyword__link--more js-figh-open-close-nav" title="Afficher le menu">
+            <i class="figh-icon-custom-plus"></i>
+        </a>
+    </div>
 
+            <script>
+            function onClickScript(index) {
+                switch(index) {
+                                            default:
+                            break;
+                }
+            }
+        </script>
+            </div>
+    </div>
+</div>
+<div class="collapsed_content figh-collapse--with-abo">
+    <a class="btn js-figh-open-close-nav figh-collapse__nav-btn">
+        <i class="burger"><i></i></i><span>Menu</span>
+    </a>
+    <div class="figh-collapse__logo">
+        <a href="/">
+            <img class="figh-logo--collapse"
+                 src="//a.f1g.fr/h/assets-components/header-footer/sport-collapse.svg"
+                 alt="Sport"/>
+        </a>
+    </div>
+            <div class="figh-abo-container">
+                        <a href="http://premium.lefigaro.fr" class="figh-abo__link">Premium</a> <a href="https://boutique.lefigaro.fr/abonnement/premium/offre/payer?origine=VWH16002&xtor=AD-727" class="figh-abo-button">Abonnez-vous</a>
+        </div>
+    </div>
+<div id="left-panel" class="figh-left-panel">
+    <div class="mobile-only js-figh-mobile-menu figh-mobile-menu figh-mobile-menu--collapsed">
+        <a class="figh-mobile-menu__item js-figh-mobileburger figh-mobile-menu__item--3" >
+            <span class="figh-mobile-menu__item-container">
+                <i class="burger"><i></i></i><br/>Menu</span>
+        </a>
+                    <a class="figh-mobile-menu__item js-figh-reader figh-mobile-menu__item--3">
+                <span class="figh-mobile-menu__item-container">
+                    <i class="figh-icon--big figh-icon-endirect">
+                        <span class="figh-reader-icon__count js-figh-reader-icon__global-count figh-reader-icon__count--hide"></span>
+                    </i>
+                    <br/>En ce moment</span>
+            </a>
+                                <a class="figh-mobile-menu__item figh-connexion js-figh-signin figh-connexion--connecting figh-mobile-menu__item--3 "
+            >
+             <span class="figh-mobile-menu__item-container figh-menu-item__container--no-border">
+                <i class="figh-icon--big figh-icon-connexion"></i>
+             </span>
+        </a>
+    </div>
+    <div id="left_menu" class="js-nav-collapsed figh-nav figh-nav--collapsed" data-id="1" data-level="0">
+                <div class="mobile-only figh-mobile-search">
+            <form class="figh-search__container js-figh-search__container" action="/l-integrale" role="search"
+                  method="GET">
+                <input class="figh-search__input js-figh-search__input--mobile" type="text"
+                       placeholder="Rechercher..." name="searchText"/>
+                null
+                <button class="figh-search__btn js-figh-search__btn">
+                    <i class="figh-icon-search"></i>
+                </button>
+            </form>
+        </div>
+                <nav class="js-figh-treenode-container figh-treenode">
+            <ul class="figh-treenode__level figh-treenode__level--0">
+            <li data-id="2"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Actualit&eacute;"  href="http://www.lefigaro.fr/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Actualit&eacute;
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="96"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Economie"  href="http://www.lefigaro.fr/economie/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Economie
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="157"
+            class="figh-treenode__item
+                                 figh-treenode__item--root-node">
+            <div class="figh-treenode__item-wrapper
+                 figh-treenode__item-wrapper--root-node                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Sport"  href="/"                   class="figh-treenode__link
+                     figh-treenode__link--root-node                                         figh-treenode__link--upper                     figh-treenode__link--bold">
+                                            Sport
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                         figh-treenode__expander--root-node                         figh-treenode__expander--open"></span>
+                            </div>
+                            <ul class="figh-treenode__level figh-treenode__level--1">
+            <li data-id="1551"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                ">
+                <a title="L&#039;actu sport en continu"  href="/l-integrale"                   class="figh-treenode__link
+                                                                                ">
+                                            L&#039;actu sport en continu
+                </a>
+                            </div>
+                    </li>
+            <li data-id="1549"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                ">
+                <a title="Tous les r&eacute;sultats"  href="/livescore"                   class="figh-treenode__link
+                                                                                ">
+                                            Tous les r&eacute;sultats
+                </a>
+                            </div>
+                    </li>
+            <li data-id="162"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Football"  href="/football"                   class="figh-treenode__link
+                                                                                ">
+                                            Football
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="186"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Tennis"  href="/tennis"                   class="figh-treenode__link
+                                                                                ">
+                                            Tennis
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="201"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Rugby"  href="/rugby"                   class="figh-treenode__link
+                                                                                ">
+                                            Rugby
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="212"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Basket"  href="/basket"                   class="figh-treenode__link
+                                                                                ">
+                                            Basket
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="221"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Auto-Moto"  href="/auto-moto"                   class="figh-treenode__link
+                                                                                ">
+                                            Auto-Moto
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="1429"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Handball"  href="/handball/"                   class="figh-treenode__link
+                                                                                ">
+                                            Handball
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="231"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Cyclisme"  href="/cyclisme"                   class="figh-treenode__link
+                                                                                ">
+                                            Cyclisme
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="250"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Voile"  href="/voile"                   class="figh-treenode__link
+                                                                                ">
+                                            Voile
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="251"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Golf"  href="http://golf.lefigaro.fr/"                   class="figh-treenode__link
+                                                                                ">
+                                            Golf
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="244"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Jeux Olympiques"  href="/jeux-olympiques"                   class="figh-treenode__link
+                                                                                ">
+                                            Jeux Olympiques
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="238"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Plus de sports"                    class="figh-treenode__link
+                                                                                ">
+                                            Plus de sports
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="488"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                ">
+                <a title="Vid&eacute;os Sport"  href="http://video.lefigaro.fr/sport24/"                   class="figh-treenode__link
+                                                                                ">
+                                            Vid&eacute;os Sport
+                </a>
+                            </div>
+                    </li>
+            <li data-id="735"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                ">
+                <a title="Diapo Sport"  href="/diaporamas"                   class="figh-treenode__link
+                                                                                ">
+                                            Diapo Sport
+                </a>
+                            </div>
+                    </li>
+            <li data-id="160"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Le Scan Sport"  href="/le-scan-sport"                   class="figh-treenode__link
+                                                                                ">
+                                            Le Scan Sport
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="736"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Blogs Sport"                    class="figh-treenode__link
+                                                                                ">
+                                            Blogs Sport
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="1462"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                ">
+                <a title="Paris sportifs"  href="/paris-sportifs"                   class="figh-treenode__link
+                                                                                ">
+                                            Paris sportifs
+                </a>
+                            </div>
+                    </li>
+            <li data-id="1143"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Bons Plans"                    class="figh-treenode__link
+                                                                                ">
+                                            Bons Plans
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+    </ul>                    </li>
+            <li data-id="252"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Culture"  href="http://www.lefigaro.fr/culture/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Culture
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="354"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Lifestyle"  href="http://www.lefigaro.fr/lifestyle/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Lifestyle
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="417"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Madame"  href="http://madame.lefigaro.fr/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Madame
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="464"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Le Figaro Premium"  href="http://www.lefigaro.fr/mon-figaro"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Le Figaro Premium
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="465"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Services"  href="http://www.lefigaro.fr/services/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Services
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="472"
+            class="figh-treenode__item
+                                ">
+            <div class="figh-treenode__item-wrapper
+                                 figh-treenode__item-wrapper--has-child js-arrow-event">
+                <a title="Tous les sites du Figaro"  href="http://www.lefigaro.fr/"                   class="figh-treenode__link
+                                                             figh-treenode__link--upper                    ">
+                                            Tous les sites du Figaro
+                </a>
+                                    <span class="figh-treenode__expander figh-icon-angle-up
+                                                "></span>
+                            </div>
+                    </li>
+            <li data-id="1191"
+            class="figh-treenode__item
+                 figh-treenode__item--hide-premium                ">
+            <div class="figh-treenode__item-wrapper
+                                ">
+                <a title="Abonnez-vous"  href="https://boutique.lefigaro.fr/abonnement/premium/offre/payer"                   class="figh-treenode__link
+                                         figh-treenode__link--ad                     figh-treenode__link--upper                    ">
+                                            <span class="figh-icon-ad" style="background-color:#c79900"></span>
+                                            Abonnez-vous
+                </a>
+                            </div>
+                    </li>
+    </ul>        </nav>
+
+    </div>
+            <div id="reader-block" class="js-reader-collapsed figh-reader figh-reader--collapsed">
+    <div class="figh-reader__container">
+    </div>
+</div>        <div id="signin-block" class="figh-sign-in js-figh-signin-block mobile-only">
+        <div class="figh-sign-in__container">
+        </div>
+    </div>
+</div>
+<div id="right-panel" class="figh-right-panel figh-logged figh-logged--collapsed">
+    <div class="figh-logged__container">
+        <ul class="figh-user-menu-liste1 figh-logged__list figh-logged__list--bold"></ul>
+        <ul class="figh-user-menu-liste2 figh-logged__list"></ul>
+        <ul class="figh-user-menu-liste3 figh-logged__list"></ul>
+        <ul class="figh-user-menu-liste4 figh-logged__list"></ul>
+    </div>
+</div>
+<div class="header-placeholder"></div>
 </header>
             <link href="//a.f1g.fr/h/assets-components/header-footer/jquery.ultimate-smartbanner.css" rel="stylesheet">
-        <script src="//a.f1g.fr/h/assets-components/header-footer/jquery.app-banner.js"></script>
     <script id="fig-header-script">
     var headerRootNodeId = '157';
     var headerId = '3';
-    var treeNodeCacheKiller = 'dff4f';
+    var treeNodeCacheKiller = '6e664';
 
-            var headerLogoNoSvg = '//a.f1g.fr/h/assets-components/header-footer/sport-fallback.png';
-                                        
+            
+                var headerLogoNoSvg = '//a.f1g.fr/h/assets-components/header-footer/sport-fallback.png';
+                                                            
                     var treenode_html_url = '//a.f1g.fr/h/assets-components/header-footer/header-treenode.js';
     
     var headerGaVarName = false;
-    var readerUrl = '\x2F\x2Fa.f1g.fr\x2Fh\x2Fassets\x2Dcomponents\x2Fheader\x2Dfooter\x2F3\x2Dreader.js';
-
-    headerOnSetup();
-
+        var readerUrl = '\x2F\x2Fa.f1g.fr\x2Fh\x2Fassets\x2Dcomponents\x2Fheader\x2Dfooter\x2F3\x2Dreader.js';
+    
     
 
 
@@ -886,592 +1072,1653 @@ var injectNewMeta = function(name, content) {
     return;
 };
 
-                        injectNewMeta('apple-itunes-app', "app-id=378095281");
-                            injectNewMeta('apple-itunes-app-tracking', "http://logc111.xiti.com/go.click?xts=526083&amp;s2=1&amp;p=SmartApp&amp;clic=T&amp;type=click&amp;url=https://itunes.apple.com/fr/app/sport24.com-actualite-sportive/id378095281?mt=8");
+                        injectNewMeta('apple\x2Ditunes\x2Dapp', "app-id=378095281");
+                            injectNewMeta('apple\x2Ditunes\x2Dapp\x2Dtracking', "http\x3A\x2F\x2Flogc111.xiti.com\x2Fgo.click\x3Fxts\x3D526083\x26s2\x3D1\x26p\x3DSmartApp\x26clic\x3DT\x26type\x3Dclick\x26url\x3Dhttps\x3A\x2F\x2Fitunes.apple.com\x2Ffr\x2Fapp\x2Fsport24.com\x2Dactualite\x2Dsportive\x2Fid378095281\x3Fmt\x3D8");
             
-                        injectNewMeta('apple-itunes-app-tab', "app-id=378095281");
-                            injectNewMeta('apple-itunes-app-tab-tracking', "http://logc111.xiti.com/go.click?xts=526083&amp;s2=1&amp;p=SmartApp&amp;clic=T&amp;type=click&amp;url=https://itunes.apple.com/fr/app/sport24.com-actualite-sportive/id378095281?mt=8");
+                        injectNewMeta('apple\x2Ditunes\x2Dapp\x2Dtab', "app-id=378095281");
+                            injectNewMeta('apple\x2Ditunes\x2Dapp\x2Dtab\x2Dtracking', "http\x3A\x2F\x2Flogc111.xiti.com\x2Fgo.click\x3Fxts\x3D526083\x26s2\x3D1\x26p\x3DSmartApp\x26clic\x3DT\x26type\x3Dclick\x26url\x3Dhttps\x3A\x2F\x2Fitunes.apple.com\x2Ffr\x2Fapp\x2Fsport24.com\x2Dactualite\x2Dsportive\x2Fid378095281\x3Fmt\x3D8");
             
-                        injectNewMeta('google-play-app', "app-id=com.sport24.android");
-                            injectNewMeta('google-play-app-tracking', "http://logc111.xiti.com/go.click?xts=526083&amp;s2=2&amp;p=SmartApp&amp;clic=T&amp;type=click&amp;url=https://play.google.com/store/apps/details?id=com.sport24.android&amp;hl=fr_FR");
+                        injectNewMeta('google\x2Dplay\x2Dapp', "app-id=com.sport24.android");
+                            injectNewMeta('google\x2Dplay\x2Dapp\x2Dtracking', "http\x3A\x2F\x2Flogc111.xiti.com\x2Fgo.click\x3Fxts\x3D526083\x26s2\x3D2\x26p\x3DSmartApp\x26clic\x3DT\x26type\x3Dclick\x26url\x3Dhttps\x3A\x2F\x2Fplay.google.com\x2Fstore\x2Fapps\x2Fdetails\x3Fid\x3Dcom.sport24.android\x26hl\x3Dfr_FR");
             
     
     
     
 
 
+
+    
+    
+    
+    
+    
+    
 var options = {
-    "title": "Le Figaro",     "author": "Soci\u00E9t\u00E9\x20du\x20Figaro",     "price": "GRATUIT",     "priceText": "",     "icon": "//a.f1g.fr/assets-img/favicons/apple-touch-icon-144x144.png",     "button": " T\u00E9l\u00E9charger",     "appStoreLanguage": "fr",     "iphoneConfig": {    "title": "Sport24.com\x20\x3A\x20Actualit\u00E9\x20sportive,\x20r\u00E9sultats,\x20matchs\x20et\x20classements\x20en\x20direct","author": "Soci\u00E9t\u00E9\x20du\x20Figaro","price": "Gratuit","icon": "http\x3A\x2F\x2Fa1.mzstatic.com\x2Feu\x2Fr30\x2FPurple\x2Fv4\x2F4c\x2F0a\x2F9f\x2F4c0a9f5a\x2D9844\x2De0b1\x2D3c80\x2D7fb5b2ee4a73\x2Ficon350x350.jpeg"},
-    "ipadConfig": {    "title": "Sport24.com\x20\x3A\x20Actualit\u00E9\x20sportive,\x20r\u00E9sultats,\x20matchs\x20et\x20classements\x20en\x20direct","author": "Soci\u00E9t\u00E9\x20du\x20Figaro","price": "Gratuit","icon": "http\x3A\x2F\x2Fa1.mzstatic.com\x2Feu\x2Fr30\x2FPurple\x2Fv4\x2F4c\x2F0a\x2F9f\x2F4c0a9f5a\x2D9844\x2De0b1\x2D3c80\x2D7fb5b2ee4a73\x2Ficon350x350.jpeg"},
-    "androidConfig": {    "title": "Sport24\x20\x3A\x20l\x27actualit\u00E9\x20sportive","author": "Le\x20Figaro","price": "Gratuit","icon": "https\x3A\x2F\x2Flh6.ggpht.com\x2F_Un52xo5g29zXuKy2SDa\x2DtZRvaJuX5ukHXelvybM6YdSEa4H8mOlNr8yjTe2GzVnOesc\x3Dw300"},
-    "androidTabsConfig": {    },
-    "windowsPhoneConfig": {    },
-    "windowsRtConfig": {    }
+    "title": "Le Figaro",     "author": "Soci\u00E9t\u00E9\x20du\x20Figaro",     "price": "GRATUIT",     "priceText": "",     "icon": "//a.f1g.fr/assets-img/favicons/apple-touch-icon-144x144.png",     "button": " T\u00E9l\u00E9charger",     "appStoreLanguage": "fr",     "iphoneConfig": {    "title": "Profitez\x20de\x20toute\x20l\x27actualit\u00E9\x20sport\x20et\x20suivez\x20les\x20matchs\x20en\x20direct\x20sur\x20votre\x20application\x20Sport24","author": "Soci\u00E9t\u00E9\x20du\x20Figaro","price": "Gratuit","icon": "http\x3A\x2F\x2Fa1.mzstatic.com\x2Feu\x2Fr30\x2FPurple\x2Fv4\x2F4c\x2F0a\x2F9f\x2F4c0a9f5a\x2D9844\x2De0b1\x2D3c80\x2D7fb5b2ee4a73\x2Ficon350x350.jpeg"},
+    "ipadConfig": {    "title": "Profitez\x20de\x20toute\x20l\x27actualit\u00E9\x20sport\x20et\x20suivez\x20les\x20matchs\x20en\x20direct\x20sur\x20votre\x20application\x20Sport24","author": "Soci\u00E9t\u00E9\x20du\x20Figaro","price": "Gratuit","icon": "http\x3A\x2F\x2Fa1.mzstatic.com\x2Feu\x2Fr30\x2FPurple\x2Fv4\x2F4c\x2F0a\x2F9f\x2F4c0a9f5a\x2D9844\x2De0b1\x2D3c80\x2D7fb5b2ee4a73\x2Ficon350x350.jpeg"},
+    "androidConfig": {    "title": "Profitez\x20de\x20toute\x20l\x27actualit\u00E9\x20sport\x20et\x20suivez\x20les\x20matchs\x20en\x20direct\x20sur\x20votre\x20application\x20Sport24","author": "Le\x20Figaro","price": "Gratuit","icon": "https\x3A\x2F\x2Flh6.ggpht.com\x2F_Un52xo5g29zXuKy2SDa\x2DtZRvaJuX5ukHXelvybM6YdSEa4H8mOlNr8yjTe2GzVnOesc\x3Dw300"},
+    "androidTabsConfig": {    "title": "Voulez\x2Dvous\x20installer\x20l\x27application\x20\x22\x22\x20\x3F",},
+    "windowsPhoneConfig": {    "title": "Voulez\x2Dvous\x20installer\x20l\x27application\x20\x22\x22\x20\x3F",},
+    "windowsRtConfig": {    "title": "Voulez\x2Dvous\x20installer\x20l\x27application\x20\x22\x22\x20\x3F",}
 };
-    jQuery(function(){
-        smartAppConfirm(options, function() {
-            // Display the smartbanner as rollback :
-        jQuery.smartbanner(options);
-        });
-    });
+
+window.loadSmartbanner = true;
 
 </script>
-		
-						
-					<!-- ESI-START called [/layout/set/esi/content/view/pubNord/822050] -->	<!--
-        ESI Generated : 14:39 27 août 2015
-        TTL : 
--->
 
-			<!-- ESI-START called [/layout/set/esi/content/view/pubNord/807404] -->	<!--
-        ESI Generated : 16:54 27 août 2015
-        TTL : 
--->
-
-	<!-- ESI-START called [/layout/set/esi/content/view/pubNord/807402] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubNord/543113] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubNord/59] -->	<!--
-        ESI Generated : 17:08 27 août 2015
-        TTL : 
--->
-
-			<section class="pub_banner">
-			<!-- HABILLAGE - FOOTBALL Habillage -->
-<script type="text/javascript" src="//ad.adxcore.com/adjs_r.php?what=zone:139265&inf=no"></script>
-
-<!-- MEGABAN ATF - FOOTBALL  -->
-<script type="text/javascript" src="//ad.adxcore.com/adjs_r.php?what=zone:139263&inf=no"></script>
-		</section>
-	<!-- ESI-END -->
-	<!-- ESI-END -->
-	<!-- ESI-END --><!-- ESI-END -->
-	<!-- ESI-END -->
-					
-									</section>
-		<section id="main" role="main" class="container_6">
-							<section id="fil_ariane" >
-	<ul class="texte_3">
-		<li><a href="/">Accueil</a></li>
-					<li>
-									<a href="/football">Football</a>
-							</li>
-					<li>
-									<a href="/football/coupe-du-monde">Coupe du monde</a>
-							</li>
-					<li>
-									<a href="/football/coupe-du-monde/2014-bresil">2014-Brésil</a>
-							</li>
-					<li>
-									<a href="/football/coupe-du-monde/2014-bresil">Fil info</a>
-							</li>
-				<li class="last_li">
-												<a href="/football/coupe-du-monde/2014-bresil/fil-info/ronaldo-ecourte-l-entrainement-700221">Ronaldo écourte l'entraînement</a>
-									</li>
-	</ul>
-</section>			            
+                                                                                        <div>
+                        <div id="habillage">
+                            <div></div>
+                        </div>
+                    </div>
+                                <div id="intrusif"></div>
+                <div class="s24-banner-pub">
+                    <div id="mban_atf"></div>
+                </div>
             
-			<!-- ESI-START called [/layout/set/esi/content/view/comp_menu/822050] -->	<!--
-        ESI Generated : 14:39 27 août 2015
-        TTL : 
--->
-
-                    
-    
-	
-        
-					
-	<nav role="navigation">
-		<ul id="nav_inferieur" style="background: url(/var/plain_site/storage/images/football/coupe-du-monde/2014-bresil/16870725-1-fre-FR/2014-Bresil.jpg) no-repeat 0 0;">
-									<li><a href="/football/coupe-du-monde/actualites/le-calendrier-de-la-coupe-du-monde-2014" class="bouton_large bouton_gris bouton_sousmenu">Programme complet</a></li>
-												<li><a href="http://sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil/equipe-de-france" class="bouton_large bouton_gris bouton_sousmenu">Equipe de France</a></li>
-												<li><a href="/livescore/football/coupe-du-monde/2014" class="bouton_large bouton_gris bouton_sousmenu">Classement/Résultats</a></li>
-												<li><a href="http://sport24.lefigaro.fr/foot-center/coupe-du-monde/index.html#/home" class="bouton_large bouton_gris bouton_sousmenu">Le Mondial en stats</a></li>
-																				                		</ul>
-	</nav>
-	
-<!-- ESI-END -->
-			
-
-															
-	<script type="text/javascript">var sptypecontenu='newsfeed';</script>	
-
-<section id="page_depeche" class="bloc">	
-	<section class="grid_4">
-        <article class="texte_1">
-			<h1><span class="titre titre_1">
-Ronaldo écourte l'entraînement</span></h1>
-			<span class="entete">18/06 16h58 - Foot, CM 2014</span>
-            <!-- ESI-START called [/layout/set/esi/content/view/toolbar_fil/822050] -->	<!--
-        ESI Generated : 14:39 27 août 2015
-        TTL : 
--->
-
-<section id="toolbar">
-    <ul>
-        <li><a href="/content/tipafriend/822050" " title="Envoyer à un ami"><img src="/extension/sport24/design/site/images/Toolbar-Article/share-email.png" alt=""/></a></li>
-        <li>
-            
-                <script>(function(d, s, id) {
+                                    <div id="page" class="s24-art">
+        <nav class="s24-arianne" itemprop="breadcrumb">
+                <ul class="s24-arianne__list"><li class="s24-arianne__link"><a href="/"><i class="s24-icon-home"></i>Accueil</a></li><li class="s24-arianne__link"><a href="http://sport24.lefigaro.fr/football"><span>Football</span></a></li><li class="s24-arianne__link"><a href="http://sport24.lefigaro.fr/football/coupe-du-monde"><span>Coupe du monde</span></a></li><li class="s24-arianne__link"><a href="http://sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil"><span>2014-Brésil</span></a></li></ul>
+        </nav>
+        <article itemtype="http://schema.org/Article" itemscope>
+                            <div class="s24-art-header s24-art-header--no-img">
+                    <h1 class="s24-art-header__title" itemprop="headline"><span>Ronaldo écourte l&#039;entraînement</span></h1>
+                </div>
+                        <div class="s24-art-share">
+                <ul>
+    <li class="s24-art-share__item">Partages</li>
+    <li class="s24-art-share__item">
+        <a href="#">
+            <i class="s24-icon-facebook"
+               data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;822050&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+            ></i>
+        </a>
+        <div class="s24-art-share__tooltip">
+            <span class="s24-art-share__link">
+                <script>
+                    (function(d, s, id) {
                         var js, fjs = d.getElementsByTagName(s)[0];
                         if (d.getElementById(id)) return;
                         js = d.createElement(s); js.id = id;
                         js.src = "//connect.facebook.net/fr_FR/all.js#xfbml=1";
                         fjs.parentNode.insertBefore(js, fjs);
-                    }(document, 'script', 'facebook-jssdk'));</script>
-            
-            <div id="fb-root"></div>
-            <div class="fb-like" data-send="false" data-layout="button_count" data-width="90" data-show-faces="false"></div>
-        </li>
-        <li class="twitter">
-            
-                <a href="https://twitter.com/share" class="twitter-share-button" data-lang="fr">Tweeter</a>
-                <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-            
-        </li>
-        <li>
-            <div class="g-plusone" data-size="medium"></div>
-            
+                    }(document, 'script', 'facebook-jssdk'));
+                </script>
+                <div id="fb-root"></div>
+                <div class="fb-like" data-layout="button_count" data-action="like" data-show-faces="false" data-share="false"></div>
+            </span>
+        </div>
+    </li>
+    <li class="s24-art-share__item">
+        <a href="#">
+            <i class="s24-icon-twitter"
+               data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;822050&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+            ></i>
+        </a>
+        <div class="s24-art-share__tooltip">
+            <span class="s24-art-share__link">
+                <a href="https://twitter.com/share" class="twitter-share-button">Tweet</a>
+                <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+            </span>
+        </div>
+    </li>
+    <li class="s24-art-share__item">
+        <a href="#">
+            <i class="s24-icon-google-plus"
+               data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;822050&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+            ></i>
+        </a>
+        <div class="s24-art-share__tooltip">
+            <span class="s24-art-share__link">
+                <g:plusone size="medium" annotation="none"></g:plusone>
                 <script type="text/javascript">
-                    window.___gcfg = {lang: 'fr'};
+                    window.___gcfg = {
+                        lang: 'en-US'
+                    };
                     (function() {
                         var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
                         po.src = 'https://apis.google.com/js/plusone.js';
                         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
                     })();
                 </script>
+            </span>
+        </div>
+    </li>
+    <li class="s24-art-share__item">
+        <a href="#">
+            <i class="s24-icon-linkedin"
+               data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;822050&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+            ></i>
+        </a>
+        <div class="s24-art-share__tooltip">
+            <span class="s24-art-share__link">
+                <script type="IN/Share" data-url="sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil/fil-info/ronaldo-ecourte-l-entrainement-700221" data-counter="top"></script>
+            </span>
+        </div>
+    </li>
+    <li class="s24-art-share__item s24-art-share__item--print">
+        <a href="javascript:window.print()" title="Imprimer cet article">
+            <i class="s24-icon-print"
+               data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;print&quot;, &quot;customIDSPE&quot;: &quot;822050&quot;, &quot;customActionSPE&quot;: &quot;print&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+            ></i>
+        </a>
+    </li>
+    <li class="s24-art-share__item s24-art-share__item--resize">
+        <i>A</i><i>A</i>
+    </li>
+     </ul>            </div>
+            <div class="s24-art__content s24-art__resize">
+                <aside class="s24-art-meta">
+                    <p itemscope itemtype="http://schema.org/Person" itemprop="author" class="s24-art-meta__author">
+        Par <span itemprop="name">
+                            La rédaction
+                    </span></p><p>
+                    Mis à jour le <span itemprop="dateModified">18/06/2014</span> à 17h03 –
+                Publié le <span itemprop="datePublished">18/06/2014</span> à 17h02
+    </p>                </aside>
+                                                                                <div class="s24-art-pub-top">
+                                                                                            <div id="pave_atf"></div>
+                            
+                                                    </div>
+                    
+                    <div class="s24-art-body" itemprop="articleBody">
+                                                                                                                            <p>Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace sur un genou, comme il l’a déjà fait à plusieurs reprises depuis son arrivée au Brésil.</p><p><em><strong>Les statistiques du Portugal en Coupe du monde :</strong></em></p><iframe src="http://sport24.lefigaro.fr/foot-center/coupe-du-monde/embed.html#/nation/portugal/historique/parcours" frameborder="0" width="500" height="421"></iframe> 
+                                                            
+                                                    
+                                            </div>
+                            </div>
+        </article>
+                    <div class="s24-art__content">
+                                    <div class="OUTBRAIN" data-src="http://sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil/fil-info/ronaldo-ecourte-l-entrainement-700221" data-widget-id="AR_6" data-ob-template="sport24fr"></div>
+<script type="text/javascript" async="async" src="http://widgets.outbrain.com/outbrain.js"></script>
+<div class="OUTBRAIN" data-src="http://sport24.lefigaro.fr/football/coupe-du-monde/2014-bresil/fil-info/ronaldo-ecourte-l-entrainement-700221" data-widget-id="AR_7" data-ob-template="sport24fr" ></div>                                <div id="mb_container" style="margin-top: 20px"></div>
+<div id="mb_video_sponso"></div>
+<script>
+    (function(){
+        var sc = document.createElement('script');
+        sc.src = 'http://player.mediabong.com/se/s24/detect/821.js';
+        sc.type = 'text/javascript';
+        sc.async = true;
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sc, s);
+    })();
+</script>            </div>
+            </div>
+    <div class="s24-art__wrapper">
+                            <div class="s24-shopping">
+    <div class="s24-shopping__content">
+        <div class="s24-shopping__title">Partenaires</div>
+        <div class="s24-shopping__partenaires">
+            <div class="s24-shopping__partenaire">
+                <iframe width="100%" height="420px" data-reactid=".3.$=11:0.0.0" scrolling="no" src="http://shoppingbox.leguide.com/sport/002"></iframe>
+            </div>
+            <div class="s24-shopping__partenaire">
+                <iframe width="300px" height="555px" border="0" scrolling="no" src="/bundles/sport24site/pages/bazarchic/index.html"></iframe>
+            </div>
+                            <div class="s24-shopping__partenaire">
+                                        <div id="pave_btf"></div>
+                </div>
+                    </div>
+    </div>
+</div>                            <div class="s24-most">
+        <h2 class="s24-most__slogan"><span class="s24-most__slogan-title">Le meilleur de l'actualité sportive</span></h2>
+                    <nav class="s24-most__nav">
+                <ul>
+                                            <li class="s24-most__nav-item s24-most__nav-item--active" id="most_popular"><span>Les + populaires</span></li>                                                                                                                        <li class="s24-most__nav-item" id="most_commented"><span>Les + commentés</span></li>                                                                                                                        <li class="s24-most__nav-item" id="most_shared"><span>Les + partagés</span></li>                                                                                                                </ul>
+            </nav>
+                            <div class="s24-most__dropdown">
+                    <div class="s24-most__dropdown-title">                                <span id="most_popular">Les + populaires</span>
+                            <i class="s24-icon-angle-down"></i></div>
+                    <nav class="s24-most__dropdown-list">
+                        <ul>
+                            <li class="s24-most__dropdown-item"><span id="most_commented">Les + commentés</span></li><li class="s24-most__dropdown-item"><span id="most_shared">Les + partagés</span></li>                        </ul>
+                    </nav>
+                </div>
+                    
+                    <ul class="s24-most__list" id="most_popular__items">
+                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/ronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284/23135448-1-fre-FR/Ronaldo-vrai-depart-ou-nouveau-coup-de-bluff_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Ronaldo: «Je m’en vais du Real, c’est décidé. Il n’y a plus de marche arrière possible»"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/ronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284">RONALDO: «JE M’EN VAIS DU REAL, C’EST DÉCIDÉ. IL N’Y A  ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/ronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981443, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            4
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+378<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284&amp;text=Ronaldo%3A%20%C2%ABJe%20m%E2%80%99en%20vais%20du%20Real%2C%20c%E2%80%99est%20d%C3%A9cid%C3%A9.%20Il%20n%E2%80%99y%20a%20plus%20de%20marche%20arri%C3%A8re%20possible%C2%BB&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284&amp;text=Ronaldo%3A%20%C2%ABJe%20m%E2%80%99en%20vais%20du%20Real%2C%20c%E2%80%99est%20d%C3%A9cid%C3%A9.%20Il%20n%E2%80%99y%20a%20plus%20de%20marche%20arri%C3%A8re%20possible%C2%BB"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/auto-moto/endurance/24h-du-mans/actualites/l-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543/23142932-4-fre-FR/L-ecurie-Jackie-Chan-et-le-jeune-Thomas-Laurent-brillent-avec-Oreca_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="L’écurie Jackie Chan et le jeune Thomas Laurent brillent avec Oreca"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/l-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543">L’ÉCURIE JACKIE CHAN ET LE JEUNE THOMAS LAURENT BRILLEN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/l-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981690, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            3
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+21<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fl-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981690&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fl-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543&amp;text=L%E2%80%99%C3%A9curie%20Jackie%20Chan%20et%20le%20jeune%20Thomas%20Laurent%20brillent%20avec%20Oreca&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981690&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fl-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981690&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fl-ecurie-jackie-chan-et-le-jeune-thomas-laurent-brillent-avec-oreca-864543&amp;text=L%E2%80%99%C3%A9curie%20Jackie%20Chan%20et%20le%20jeune%20Thomas%20Laurent%20brillent%20avec%20Oreca"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981690&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/qui-pourra-s-offrir-cristiano-ronaldo-864356/23137450-5-fre-FR/Qui-peut-s-offrir-Cristiano-Ronaldo_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Qui peut s’offrir Cristiano Ronaldo ?"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/qui-pourra-s-offrir-cristiano-ronaldo-864356">QUI PEUT S’OFFRIR CRISTIANO RONALDO ?</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/qui-pourra-s-offrir-cristiano-ronaldo-864356#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981512, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            6
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+151<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fqui-pourra-s-offrir-cristiano-ronaldo-864356&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981512&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fqui-pourra-s-offrir-cristiano-ronaldo-864356&amp;text=Qui%20peut%20s%E2%80%99offrir%20Cristiano%20Ronaldo%20%3F&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981512&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fqui-pourra-s-offrir-cristiano-ronaldo-864356"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981512&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fqui-pourra-s-offrir-cristiano-ronaldo-864356&amp;text=Qui%20peut%20s%E2%80%99offrir%20Cristiano%20Ronaldo%20%3F"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981512&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/auto-moto/endurance/24h-du-mans/actualites/auteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514/23142148-1-fre-FR/Auteur-d-une-magnifique-remontada-Porsche-triomphe-encore-au-Mans_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Grâce à une magnifique «remontada», Porsche triomphe encore au Mans"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/auteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514">GRÂCE À UNE MAGNIFIQUE «REMONTADA», PORSCHE TRIOMPHE EN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/auteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981663, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            18
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+175<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514&amp;text=Gr%C3%A2ce%20%C3%A0%20une%20magnifique%20%C2%ABremontada%C2%BB%2C%20Porsche%20triomphe%20encore%20au%20Mans&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514&amp;text=Gr%C3%A2ce%20%C3%A0%20une%20magnifique%20%C2%ABremontada%C2%BB%2C%20Porsche%20triomphe%20encore%20au%20Mans"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/les-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423/23139439-2-fre-FR/Les-notes-des-Bleus-face-a-l-Afrique-du-Sud-le-fiasco-Trinh-Duc-les-bons-debuts-de-Penaud_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Les notes des Bleus face à l'Afrique du Sud : le fiasco Trinh-Duc, les bons débuts de Penaud "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/les-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423">LES NOTES DES BLEUS FACE À L&#039;AFRIQUE DU SUD : LE FIASCO ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/les-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981576, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            5
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+50<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981576&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423&amp;text=Les%20notes%20des%20Bleus%20face%20%C3%A0%20l%27Afrique%20du%20Sud%20%3A%20le%20fiasco%20Trinh-Duc%2C%20les%20bons%20d%C3%A9buts%20de%20Penaud%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981576&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981576&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-afrique-du-sud-le-fiasco-trinh-duc-les-bons-debuts-de-penaud-864423&amp;text=Les%20notes%20des%20Bleus%20face%20%C3%A0%20l%27Afrique%20du%20Sud%20%3A%20le%20fiasco%20Trinh-Duc%2C%20les%20bons%20d%C3%A9buts%20de%20Penaud%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981576&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/france-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888/23125119-1-fre-FR/France-Angleterre-Le-vibrant-hommage-du-Stade-de-France-aux-victimes-des-attentats.jpg" width="175" height="175" class="s24-most__img" alt="France-Angleterre : Le vibrant hommage du Stade de France aux victimes des attentats"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/france-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888">FRANCE-ANGLETERRE : LE VIBRANT HOMMAGE DU STADE DE FRAN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/france-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981062, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            14
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+97<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888&amp;text=France-Angleterre%20%3A%20Le%20vibrant%20hommage%20du%20Stade%20de%20France%20aux%20victimes%20des%20attentats&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888&amp;text=France-Angleterre%20%3A%20Le%20vibrant%20hommage%20du%20Stade%20de%20France%20aux%20victimes%20des%20attentats"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/les-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917/23125980-1-fre-FR/Les-notes-des-Bleus-face-a-l-Angleterre-Mbappe-et-Dembele-regalent-Pogba-s-eclate_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Les notes des Bleus face à l'Angleterre : Mbappé et Dembélé régalent, Pogba s’éclate"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/les-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917">LES NOTES DES BLEUS FACE À L&#039;ANGLETERRE : MBAPPÉ ET DEM ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/les-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981090, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            5
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+632<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917&amp;text=Les%20notes%20des%20Bleus%20face%20%C3%A0%20l%27Angleterre%20%3A%20Mbapp%C3%A9%20et%20Demb%C3%A9l%C3%A9%20r%C3%A9galent%2C%20Pogba%20s%E2%80%99%C3%A9clate&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917&amp;text=Les%20notes%20des%20Bleus%20face%20%C3%A0%20l%27Angleterre%20%3A%20Mbapp%C3%A9%20et%20Demb%C3%A9l%C3%A9%20r%C3%A9galent%2C%20Pogba%20s%E2%80%99%C3%A9clate"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/ou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261/23134907-1-fre-FR/Ou-voir-Afrique-du-Sud-France-et-cinq-choses-a-savoir-sur-le-deuxieme-test.jpg" width="175" height="175" class="s24-most__img" alt="Où voir Afrique du Sud-France et cinq choses à savoir sur le deuxième test"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/ou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261">OÙ VOIR AFRIQUE DU SUD-FRANCE ET CINQ CHOSES À SAVOIR S ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/ou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981420, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            0
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+12<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981420&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261&amp;text=O%C3%B9%20voir%20Afrique%20du%20Sud-France%20et%20cinq%20choses%20%C3%A0%20savoir%20sur%20le%20deuxi%C3%A8me%20test&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981420&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981420&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fou-voir-afrique-du-sud-france-et-cinq-choses-a-savoir-sur-le-deuxieme-test-864261&amp;text=O%C3%B9%20voir%20Afrique%20du%20Sud-France%20et%20cinq%20choses%20%C3%A0%20savoir%20sur%20le%20deuxi%C3%A8me%20test"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981420&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/laporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063/23129913-1-fre-FR/Laporte-et-la-Tournee-du-XV-de-France-Certaines-choses-sont-inadmissibles_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Laporte et la Tournée du XV de France : «Certaines choses sont inadmissibles» "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/laporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063">LAPORTE ET LA TOURNÉE DU XV DE FRANCE : «CERTAINES CHOS ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/laporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981227, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            6
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+17<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063&amp;text=Laporte%20et%20la%20Tourn%C3%A9e%20du%20XV%20de%20France%20%3A%20%C2%ABCertaines%20choses%20sont%20inadmissibles%C2%BB%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063&amp;text=Laporte%20et%20la%20Tourn%C3%A9e%20du%20XV%20de%20France%20%3A%20%C2%ABCertaines%20choses%20sont%20inadmissibles%C2%BB%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/noel-le-graet-au-figaro-zidane-fait-du-macron-863912/23125851-1-fre-FR/Noel-Le-Graet-au-Figaro-Zidane-fait-du-Macron.jpg" width="175" height="175" class="s24-most__img" alt="Noël Le Graët au Figaro : «La FFF n’achètera pas Zidane au Real Madrid»"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/noel-le-graet-au-figaro-zidane-fait-du-macron-863912">NOËL LE GRAËT AU FIGARO : «LA FFF N’ACHÈTERA PAS ZIDANE ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/noel-le-graet-au-figaro-zidane-fait-du-macron-863912#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981084, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            3
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+1715<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912&amp;text=No%C3%ABl%20Le%20Gra%C3%ABt%20au%20Figaro%20%3A%20%C2%ABLa%20FFF%20n%E2%80%99ach%C3%A8tera%20pas%20Zidane%20au%20Real%20Madrid%C2%BB&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912&amp;text=No%C3%ABl%20Le%20Gra%C3%ABt%20au%20Figaro%20%3A%20%C2%ABLa%20FFF%20n%E2%80%99ach%C3%A8tera%20pas%20Zidane%20au%20Real%20Madrid%C2%BB"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/verratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513/23142127-1-fre-FR/Verratti-aurait-mis-les-choses-au-clair-Je-ne-reviendrai-pas-a-Paris_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Verratti aurait mis les choses au clair : «Je ne reviendrai pas à Paris» "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/verratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513">VERRATTI AURAIT MIS LES CHOSES AU CLAIR : «JE NE REVIEN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/verratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981661, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            4
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+382<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513&amp;text=Verratti%20aurait%20mis%20les%20choses%20au%20clair%20%3A%20%C2%ABJe%20ne%20reviendrai%20pas%20%C3%A0%20Paris%C2%BB%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513&amp;text=Verratti%20aurait%20mis%20les%20choses%20au%20clair%20%3A%20%C2%ABJe%20ne%20reviendrai%20pas%20%C3%A0%20Paris%C2%BB%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/le-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973/23127577-1-fre-FR/Le-Barca-veut-Verratti-mais-pas-a-n-importe-quel-prix_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Le Barça veut Verratti, mais pas à n'importe quel prix"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/le-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973">LE BARÇA VEUT VERRATTI, MAIS PAS À N&#039;IMPORTE QUEL PRIX</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/le-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981143, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            0
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+582<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973&amp;text=Le%20Bar%C3%A7a%20veut%20Verratti%2C%20mais%20pas%20%C3%A0%20n%27importe%20quel%20prix&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973&amp;text=Le%20Bar%C3%A7a%20veut%20Verratti%2C%20mais%20pas%20%C3%A0%20n%27importe%20quel%20prix"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                            </ul>
+                    <ul class="s24-most__list" id="most_commented__items" style="display: none">
+                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/etranger/espagne/actualites/cristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819/23123044-1-fre-FR/Cristiano-Ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-Madrid_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Cristiano Ronaldo accusé de fraude fiscale par le parquet de Madrid"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/etranger/espagne/actualites/cristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819">CRISTIANO RONALDO ACCUSÉ DE FRAUDE FISCALE PAR LE PARQU ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/etranger/espagne/actualites/cristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981003, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            22
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+971<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819&amp;text=Cristiano%20Ronaldo%20accus%C3%A9%20de%20fraude%20fiscale%20par%20le%20parquet%20de%20Madrid&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819&amp;text=Cristiano%20Ronaldo%20accus%C3%A9%20de%20fraude%20fiscale%20par%20le%20parquet%20de%20Madrid"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/auto-moto/endurance/24h-du-mans/actualites/auteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514/23142148-1-fre-FR/Auteur-d-une-magnifique-remontada-Porsche-triomphe-encore-au-Mans_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Grâce à une magnifique «remontada», Porsche triomphe encore au Mans"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/auteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514">GRÂCE À UNE MAGNIFIQUE «REMONTADA», PORSCHE TRIOMPHE EN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/auteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981663, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            18
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+175<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514&amp;text=Gr%C3%A2ce%20%C3%A0%20une%20magnifique%20%C2%ABremontada%C2%BB%2C%20Porsche%20triomphe%20encore%20au%20Mans&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2Fauteur-d-une-magnifique-remontada-porsche-triomphe-encore-au-mans-864514&amp;text=Gr%C3%A2ce%20%C3%A0%20une%20magnifique%20%C2%ABremontada%C2%BB%2C%20Porsche%20triomphe%20encore%20au%20Mans"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981663&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/afrique-du-sud-france-en-direct-864367/23137792-5-fre-FR/Le-XV-de-France-tend-l-autre-joue-en-Afrique-du-Sud_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Désespérants, les Bleus subissent encore la loi des Springboks"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/afrique-du-sud-france-en-direct-864367">DÉSESPÉRANTS, LES BLEUS SUBISSENT ENCORE LA LOI DES SPRINGBOKS</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/afrique-du-sud-france-en-direct-864367#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981523, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            16
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+8<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-en-direct-864367&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981523&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-en-direct-864367&amp;text=D%C3%A9sesp%C3%A9rants%2C%20les%20Bleus%20subissent%20encore%20la%20loi%20des%20Springboks&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981523&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-en-direct-864367"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981523&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-en-direct-864367&amp;text=D%C3%A9sesp%C3%A9rants%2C%20les%20Bleus%20subissent%20encore%20la%20loi%20des%20Springboks"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981523&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/france-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888/23125119-1-fre-FR/France-Angleterre-Le-vibrant-hommage-du-Stade-de-France-aux-victimes-des-attentats.jpg" width="175" height="175" class="s24-most__img" alt="France-Angleterre : Le vibrant hommage du Stade de France aux victimes des attentats"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/france-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888">FRANCE-ANGLETERRE : LE VIBRANT HOMMAGE DU STADE DE FRAN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/france-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981062, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            14
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+97<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888&amp;text=France-Angleterre%20%3A%20Le%20vibrant%20hommage%20du%20Stade%20de%20France%20aux%20victimes%20des%20attentats&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-le-vibrant-hommage-du-stade-de-france-aux-victimes-des-attentats-863888&amp;text=France-Angleterre%20%3A%20Le%20vibrant%20hommage%20du%20Stade%20de%20France%20aux%20victimes%20des%20attentats"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981062&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/afrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459/23140455-1-fre-FR/Afrique-du-Sud-France-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Afrique du Sud-France : les coups de coeur et coups de griffe de notre envoyé spécial"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/afrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459">AFRIQUE DU SUD-FRANCE : LES COUPS DE COEUR ET COUPS DE  ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/afrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981613, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            12
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+25<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981613&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459&amp;text=Afrique%20du%20Sud-France%20%3A%20les%20coups%20de%20coeur%20et%20coups%20de%20griffe%20de%20notre%20envoy%C3%A9%20sp%C3%A9cial&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981613&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981613&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fafrique-du-sud-france-les-coups-de-coeur-et-coups-de-griffe-de-notre-envoye-special-864459&amp;text=Afrique%20du%20Sud-France%20%3A%20les%20coups%20de%20coeur%20et%20coups%20de%20griffe%20de%20notre%20envoy%C3%A9%20sp%C3%A9cial"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981613&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/jeux-olympiques/jo-2024/actualites/anne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178/23132671-2-fre-FR/Anne-Hidalgo-On-ne-fait-aucun-ultimatum-au-CIO-pour-2024_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Anne Hidalgo : « On ne fait aucun ultimatum au CIO pour 2024 »"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/jeux-olympiques/jo-2024/actualites/anne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178">ANNE HIDALGO : « ON NE FAIT AUCUN ULTIMATUM AU CIO POUR 2024 »</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/jeux-olympiques/jo-2024/actualites/anne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981341, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            11
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+31<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Fjeux-olympiques%2Fjo-2024%2Factualites%2Fanne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981341&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Fjeux-olympiques%2Fjo-2024%2Factualites%2Fanne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178&amp;text=Anne%20Hidalgo%20%3A%20%C2%AB%20On%20ne%20fait%20aucun%20ultimatum%20au%20CIO%20pour%202024%20%C2%BB&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981341&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fjeux-olympiques%2Fjo-2024%2Factualites%2Fanne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981341&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fjeux-olympiques%2Fjo-2024%2Factualites%2Fanne-hidalgo-on-ne-fait-aucun-ultimatum-au-cio-pour-2024-864178&amp;text=Anne%20Hidalgo%20%3A%20%C2%AB%20On%20ne%20fait%20aucun%20ultimatum%20au%20CIO%20pour%202024%20%C2%BB"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981341&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/france-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746/23120844-1-fre-FR/France-Angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="France-Angleterre, pourquoi ce n’est pas seulement une affiche de gala "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/france-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746">FRANCE-ANGLETERRE, POURQUOI CE N’EST PAS SEULEMENT UNE  ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/france-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 980936, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            10
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+146<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;980936&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746&amp;text=France-Angleterre%2C%20pourquoi%20ce%20n%E2%80%99est%20pas%20seulement%20une%20affiche%20de%20gala%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;980936&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;980936&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Ffrance-angleterre-pourquoi-ce-n-est-pas-seulement-une-affiche-de-gala-863746&amp;text=France-Angleterre%2C%20pourquoi%20ce%20n%E2%80%99est%20pas%20seulement%20une%20affiche%20de%20gala%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;980936&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/emery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080/23130397-1-fre-FR/Emery-drague-ouvertement-Mbappe-Quoi-de-plus-beau-que-de-representer-sa-ville_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Emery drague ouvertement Mbappé : «Quoi de plus beau que de représenter sa ville ?»"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/emery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080">EMERY DRAGUE OUVERTEMENT MBAPPÉ : «QUOI DE PLUS BEAU QU ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/emery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981244, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            9
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+115<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Femery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981244&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Femery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080&amp;text=Emery%20drague%20ouvertement%20Mbapp%C3%A9%20%3A%20%C2%ABQuoi%20de%20plus%20beau%20que%20de%20repr%C3%A9senter%20sa%20ville%20%3F%C2%BB&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981244&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Femery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981244&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Femery-drague-ouvertement-mbappe-quoi-de-plus-beau-que-de-representer-sa-ville-864080&amp;text=Emery%20drague%20ouvertement%20Mbapp%C3%A9%20%3A%20%C2%ABQuoi%20de%20plus%20beau%20que%20de%20repr%C3%A9senter%20sa%20ville%20%3F%C2%BB"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981244&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/oasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744/23120811-1-fre-FR/Oasis-God-Save-the-Queen-Macron-Hommages-attendus-avant-France-Angleterre_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Oasis, God Save the Queen, Macron: Hommages attendus avant France-Angleterre"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/oasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744">OASIS, GOD SAVE THE QUEEN, MACRON: HOMMAGES ATTENDUS AV ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/oasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 980932, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            8
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+69<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Foasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;980932&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Foasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744&amp;text=Oasis%2C%20God%20Save%20the%20Queen%2C%20Macron%3A%20Hommages%20attendus%20avant%20France-Angleterre&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;980932&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Foasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;980932&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Foasis-god-save-the-queen-macron-hommages-attendus-avant-france-angleterre-863744&amp;text=Oasis%2C%20God%20Save%20the%20Queen%2C%20Macron%3A%20Hommages%20attendus%20avant%20France-Angleterre"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;980932&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/pourquoi-le-xv-de-france-est-depasse-864528/23142536-1-fre-FR/Pourquoi-le-XV-de-France-est-vraiment-depasse_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Pourquoi le XV de France est (vraiment) dépassé"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/pourquoi-le-xv-de-france-est-depasse-864528">POURQUOI LE XV DE FRANCE EST (VRAIMENT) DÉPASSÉ</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/pourquoi-le-xv-de-france-est-depasse-864528#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981676, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            10
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+15<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fpourquoi-le-xv-de-france-est-depasse-864528&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981676&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fpourquoi-le-xv-de-france-est-depasse-864528&amp;text=Pourquoi%20le%20XV%20de%20France%20est%20%28vraiment%29%20d%C3%A9pass%C3%A9&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981676&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fpourquoi-le-xv-de-france-est-depasse-864528"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981676&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Fpourquoi-le-xv-de-france-est-depasse-864528&amp;text=Pourquoi%20le%20XV%20de%20France%20est%20%28vraiment%29%20d%C3%A9pass%C3%A9"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981676&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/le-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707/23119696-1-fre-FR/Le-Barca-proposerait-100-M-au-PSG-pour-Marco-Verratti_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Le Barça proposerait 100 M€ au PSG pour Marco Verratti"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/le-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707">LE BARÇA PROPOSERAIT 100 M€ AU PSG POUR MARCO VERRATTI</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/le-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 980897, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            7
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+58<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;980897&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707&amp;text=Le%20Bar%C3%A7a%20proposerait%20100%20M%E2%82%AC%20au%20PSG%20pour%20Marco%20Verratti&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;980897&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;980897&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-proposerait-100-m-au-psg-pour-marco-verratti-863707&amp;text=Le%20Bar%C3%A7a%20proposerait%20100%20M%E2%82%AC%20au%20PSG%20pour%20Marco%20Verratti"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;980897&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/rugby/xv-de-france/actualites/laporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063/23129913-1-fre-FR/Laporte-et-la-Tournee-du-XV-de-France-Certaines-choses-sont-inadmissibles_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Laporte et la Tournée du XV de France : «Certaines choses sont inadmissibles» "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/laporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063">LAPORTE ET LA TOURNÉE DU XV DE FRANCE : «CERTAINES CHOS ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/rugby/xv-de-france/actualites/laporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981227, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            6
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+17<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063&amp;text=Laporte%20et%20la%20Tourn%C3%A9e%20du%20XV%20de%20France%20%3A%20%C2%ABCertaines%20choses%20sont%20inadmissibles%C2%BB%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Frugby%2Fxv-de-france%2Factualites%2Flaporte-et-la-tournee-du-xv-de-france-certaines-choses-sont-inadmissibles-864063&amp;text=Laporte%20et%20la%20Tourn%C3%A9e%20du%20XV%20de%20France%20%3A%20%C2%ABCertaines%20choses%20sont%20inadmissibles%C2%BB%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981227&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                            </ul>
+                    <ul class="s24-most__list" id="most_shared__items" style="display: none">
+                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/noel-le-graet-au-figaro-zidane-fait-du-macron-863912/23125851-1-fre-FR/Noel-Le-Graet-au-Figaro-Zidane-fait-du-Macron.jpg" width="175" height="175" class="s24-most__img" alt="Noël Le Graët au Figaro : «La FFF n’achètera pas Zidane au Real Madrid»"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/noel-le-graet-au-figaro-zidane-fait-du-macron-863912">NOËL LE GRAËT AU FIGARO : «LA FFF N’ACHÈTERA PAS ZIDANE ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/noel-le-graet-au-figaro-zidane-fait-du-macron-863912#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981084, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            3
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+1715<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912&amp;text=No%C3%ABl%20Le%20Gra%C3%ABt%20au%20Figaro%20%3A%20%C2%ABLa%20FFF%20n%E2%80%99ach%C3%A8tera%20pas%20Zidane%20au%20Real%20Madrid%C2%BB&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fnoel-le-graet-au-figaro-zidane-fait-du-macron-863912&amp;text=No%C3%ABl%20Le%20Gra%C3%ABt%20au%20Figaro%20%3A%20%C2%ABLa%20FFF%20n%E2%80%99ach%C3%A8tera%20pas%20Zidane%20au%20Real%20Madrid%C2%BB"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981084&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/etranger/espagne/actualites/cristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819/23123044-1-fre-FR/Cristiano-Ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-Madrid_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Cristiano Ronaldo accusé de fraude fiscale par le parquet de Madrid"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/etranger/espagne/actualites/cristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819">CRISTIANO RONALDO ACCUSÉ DE FRAUDE FISCALE PAR LE PARQU ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/etranger/espagne/actualites/cristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981003, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            22
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+971<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819&amp;text=Cristiano%20Ronaldo%20accus%C3%A9%20de%20fraude%20fiscale%20par%20le%20parquet%20de%20Madrid&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fetranger%2Fespagne%2Factualites%2Fcristiano-ronaldo-accuse-de-fraude-fiscale-par-le-parquet-de-madrid-863819&amp;text=Cristiano%20Ronaldo%20accus%C3%A9%20de%20fraude%20fiscale%20par%20le%20parquet%20de%20Madrid"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981003&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/equipe-de-france/actualites/les-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917/23125980-1-fre-FR/Les-notes-des-Bleus-face-a-l-Angleterre-Mbappe-et-Dembele-regalent-Pogba-s-eclate_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Les notes des Bleus face à l'Angleterre : Mbappé et Dembélé régalent, Pogba s’éclate"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/les-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917">LES NOTES DES BLEUS FACE À L&#039;ANGLETERRE : MBAPPÉ ET DEM ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/equipe-de-france/actualites/les-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981090, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            5
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+632<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917&amp;text=Les%20notes%20des%20Bleus%20face%20%C3%A0%20l%27Angleterre%20%3A%20Mbapp%C3%A9%20et%20Demb%C3%A9l%C3%A9%20r%C3%A9galent%2C%20Pogba%20s%E2%80%99%C3%A9clate&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fequipe-de-france%2Factualites%2Fles-notes-des-bleus-face-a-l-angleterre-mbappe-et-dembele-regalent-pogba-s-eclate-863917&amp;text=Les%20notes%20des%20Bleus%20face%20%C3%A0%20l%27Angleterre%20%3A%20Mbapp%C3%A9%20et%20Demb%C3%A9l%C3%A9%20r%C3%A9galent%2C%20Pogba%20s%E2%80%99%C3%A9clate"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981090&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/le-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973/23127577-1-fre-FR/Le-Barca-veut-Verratti-mais-pas-a-n-importe-quel-prix_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Le Barça veut Verratti, mais pas à n'importe quel prix"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/le-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973">LE BARÇA VEUT VERRATTI, MAIS PAS À N&#039;IMPORTE QUEL PRIX</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/le-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981143, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            0
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+582<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973&amp;text=Le%20Bar%C3%A7a%20veut%20Verratti%2C%20mais%20pas%20%C3%A0%20n%27importe%20quel%20prix&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fle-barca-veut-verratti-mais-pas-a-n-importe-quel-prix-863973&amp;text=Le%20Bar%C3%A7a%20veut%20Verratti%2C%20mais%20pas%20%C3%A0%20n%27importe%20quel%20prix"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981143&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/basket/nba/actualites/kevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787/23122071-4-fre-FR/Kevin-Durant-un-titre-qui-valide-son-choix-et-ses-sacrifices_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Kevin Durant, un titre qui valide son choix et ses sacrifices"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/basket/nba/actualites/kevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787">KEVIN DURANT, UN TITRE QUI VALIDE SON CHOIX ET SES SACRIFICES</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/basket/nba/actualites/kevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 980973, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            0
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+473<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Fbasket%2Fnba%2Factualites%2Fkevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;980973&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Fbasket%2Fnba%2Factualites%2Fkevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787&amp;text=Kevin%20Durant%2C%20un%20titre%20qui%20valide%20son%20choix%20et%20ses%20sacrifices&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;980973&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fbasket%2Fnba%2Factualites%2Fkevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;980973&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fbasket%2Fnba%2Factualites%2Fkevin-durant-un-titre-qui-valide-son-choix-et-ses-sacrifices-863787&amp;text=Kevin%20Durant%2C%20un%20titre%20qui%20valide%20son%20choix%20et%20ses%20sacrifices"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;980973&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/coupe-du-monde/coupe-des-confederations/actualites/empetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412/23139152-1-fre-FR/Empetre-dans-les-affaires-Ronaldo-veut-s-aerer-la-tete-en-Russie_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Empêtré dans les affaires, Ronaldo veut s’aérer la tête en Russie"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/coupe-du-monde/coupe-des-confederations/actualites/empetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412">EMPÊTRÉ DANS LES AFFAIRES, RONALDO VEUT S’AÉRER LA TÊTE EN RUSSIE</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/coupe-du-monde/coupe-des-confederations/actualites/empetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981566, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            4
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+439<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fcoupe-du-monde%2Fcoupe-des-confederations%2Factualites%2Fempetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981566&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fcoupe-du-monde%2Fcoupe-des-confederations%2Factualites%2Fempetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412&amp;text=Emp%C3%AAtr%C3%A9%20dans%20les%20affaires%2C%20Ronaldo%20veut%20s%E2%80%99a%C3%A9rer%20la%20t%C3%AAte%20en%20Russie&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981566&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fcoupe-du-monde%2Fcoupe-des-confederations%2Factualites%2Fempetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981566&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Fcoupe-du-monde%2Fcoupe-des-confederations%2Factualites%2Fempetre-dans-les-affaires-ronaldo-veut-s-aerer-la-tete-en-russie-864412&amp;text=Emp%C3%AAtr%C3%A9%20dans%20les%20affaires%2C%20Ronaldo%20veut%20s%E2%80%99a%C3%A9rer%20la%20t%C3%AAte%20en%20Russie"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981566&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/l-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776/23121732-1-fre-FR/L-etonnant-classement-des-joueurs-les-plus-chers-en-Europe_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="L’étonnant classement des joueurs les plus chers en Europe"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/l-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776">L’ÉTONNANT CLASSEMENT DES JOUEURS LES PLUS CHERS EN EUROPE</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/l-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 980962, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            0
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+406<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fl-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;980962&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fl-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776&amp;text=L%E2%80%99%C3%A9tonnant%20classement%20des%20joueurs%20les%20plus%20chers%20en%20Europe&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;980962&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fl-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;980962&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fl-etonnant-classement-des-joueurs-les-plus-chers-en-europe-863776&amp;text=L%E2%80%99%C3%A9tonnant%20classement%20des%20joueurs%20les%20plus%20chers%20en%20Europe"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;980962&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/verratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513/23142127-1-fre-FR/Verratti-aurait-mis-les-choses-au-clair-Je-ne-reviendrai-pas-a-Paris_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Verratti aurait mis les choses au clair : «Je ne reviendrai pas à Paris» "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/verratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513">VERRATTI AURAIT MIS LES CHOSES AU CLAIR : «JE NE REVIEN ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/verratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981661, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            4
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+382<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513&amp;text=Verratti%20aurait%20mis%20les%20choses%20au%20clair%20%3A%20%C2%ABJe%20ne%20reviendrai%20pas%20%C3%A0%20Paris%C2%BB%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fverratti-aurait-mis-les-choses-au-clair-je-ne-reviendrai-pas-a-paris-864513&amp;text=Verratti%20aurait%20mis%20les%20choses%20au%20clair%20%3A%20%C2%ABJe%20ne%20reviendrai%20pas%20%C3%A0%20Paris%C2%BB%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981661&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/ronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284/23135448-1-fre-FR/Ronaldo-vrai-depart-ou-nouveau-coup-de-bluff_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="Ronaldo: «Je m’en vais du Real, c’est décidé. Il n’y a plus de marche arrière possible»"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/ronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284">RONALDO: «JE M’EN VAIS DU REAL, C’EST DÉCIDÉ. IL N’Y A  ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/ronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981443, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            4
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+378<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284&amp;text=Ronaldo%3A%20%C2%ABJe%20m%E2%80%99en%20vais%20du%20Real%2C%20c%E2%80%99est%20d%C3%A9cid%C3%A9.%20Il%20n%E2%80%99y%20a%20plus%20de%20marche%20arri%C3%A8re%20possible%C2%BB&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fronaldo-vrai-depart-ou-nouveau-coup-de-bluff-864284&amp;text=Ronaldo%3A%20%C2%ABJe%20m%E2%80%99en%20vais%20du%20Real%2C%20c%E2%80%99est%20d%C3%A9cid%C3%A9.%20Il%20n%E2%80%99y%20a%20plus%20de%20marche%20arri%C3%A8re%20possible%C2%BB"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981443&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/transferts/actualites/zidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516/23142190-1-fre-FR/Zidane-passe-a-l-action-pour-tenter-de-garder-Ronaldo.jpg" width="175" height="175" class="s24-most__img" alt="Zidane passe à l’action pour tenter de garder Ronaldo "/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/zidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516">ZIDANE PASSE À L’ACTION POUR TENTER DE GARDER RONALDO </a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/transferts/actualites/zidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981662, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            0
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+349<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fzidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981662&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fzidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516&amp;text=Zidane%20passe%20%C3%A0%20l%E2%80%99action%20pour%20tenter%20de%20garder%20Ronaldo%20&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981662&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fzidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981662&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Ftransferts%2Factualites%2Fzidane-passe-a-l-action-pour-tenter-de-garder-ronaldo-864516&amp;text=Zidane%20passe%20%C3%A0%20l%E2%80%99action%20pour%20tenter%20de%20garder%20Ronaldo%20"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981662&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/football/actualites/l-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509/23142007-1-fre-FR/L-enorme-addition-reglee-par-Messi-Fabregas-et-Suarez-en-vacances.png" width="175" height="175" class="s24-most__img" alt="L’énorme addition réglée par Messi, Fabregas et Suarez en vacances"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/football/actualites/l-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509">L’ÉNORME ADDITION RÉGLÉE PAR MESSI, FABREGAS ET SUAREZ  ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/football/actualites/l-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981658, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            1
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+330<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Factualites%2Fl-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981658&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Factualites%2Fl-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509&amp;text=L%E2%80%99%C3%A9norme%20addition%20r%C3%A9gl%C3%A9e%20par%20Messi%2C%20Fabregas%20et%20Suarez%20en%20vacances&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981658&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Factualites%2Fl-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981658&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Ffootball%2Factualites%2Fl-enorme-addition-reglee-par-messi-fabregas-et-suarez-en-vacances-864509&amp;text=L%E2%80%99%C3%A9norme%20addition%20r%C3%A9gl%C3%A9e%20par%20Messi%2C%20Fabregas%20et%20Suarez%20en%20vacances"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981658&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                                    <li class="s24-most__item" itemtype="http://schema.org/ImageObject" itemscope><img data-src="http://i.f1g.fr/media/ext/175x175_crop/sport24.lefigaro.fr/var/plain_site/storage/images/auto-moto/endurance/24h-du-mans/actualites/24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150/23132137-1-fre-FR/24-H-du-Mans-Thomas-Laurent-la-pepite-francaise-de-l-ecurie-Jackie-Chan_photo_2040.jpg" width="175" height="175" class="s24-most__img" alt="24 Heures du Mans : Thomas Laurent, la pépite française de l’écurie Jackie Chan"/><h3 class="s24-most__title"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150">24 HEURES DU MANS : THOMAS LAURENT, LA PÉPITE FRANÇAISE ...</a></h3><div class="s24-profil__share"><a href="http://sport24.lefigaro.fr/auto-moto/endurance/24h-du-mans/actualites/24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150#reagir" class="s24-profil__comment"><i class="s24-icon-comment"
+                                       data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;enrichment&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;commentaire&quot;, &quot;customIDSPE&quot;: 981330, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+                                    ></i>
+                                                                            5
+                                                                    </a><div class="s24-profil__partage s24-profil__partage--top"><i class="s24-icon-share" title="Partager"></i>
+319<div class="s24-popover"><div class="s24-popover__inner"><div class="s24-popover__body"><ul><li class="s24-popover__item"><a href="https://www.facebook.com/sharer/sharer.php?&amp;u=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2F24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150&amp;display=popup"
+       data-popup-width="655"
+       data-popup-height="358"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-facebook"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;facebook&quot;, &quot;customIDSPE&quot;: &quot;981330&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://twitter.com/share?url=http%3A%2F%2Fhttp%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2F24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150&amp;text=24%20Heures%20du%20Mans%20%3A%20Thomas%20Laurent%2C%20la%20p%C3%A9pite%20fran%C3%A7aise%20de%20l%E2%80%99%C3%A9curie%20Jackie%20Chan&amp;via=Sport24Team"
+       data-popup-width="629"
+       data-popup-height="257"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-twitter"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;twitter&quot;, &quot;customIDSPE&quot;: &quot;981330&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://plus.google.com/share?hl=fr&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2F24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150"
+       data-popup-width="484"
+       data-popup-height="622"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-google-plus"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;googleplus&quot;, &quot;customIDSPE&quot;: &quot;981330&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li><li class="s24-popover__item"><a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fsport24.lefigaro.fr%2Fauto-moto%2Fendurance%2F24h-du-mans%2Factualites%2F24-h-du-mans-thomas-laurent-la-pepite-francaise-de-l-ecurie-jackie-chan-864150&amp;text=24%20Heures%20du%20Mans%20%3A%20Thomas%20Laurent%2C%20la%20p%C3%A9pite%20fran%C3%A7aise%20de%20l%E2%80%99%C3%A9curie%20Jackie%20Chan"
+       data-popup-width="600"
+       data-popup-height="459"
+       target="_blank"
+       class="js-s24-share"><i class="s24-icon-linkedin"
+           data-gtm="{&quot;customCategorieBU&quot;: &quot;navigation&quot;, &quot;customActionBU&quot;: &quot;socialSharing&quot;, &quot;customLabelBUcustomCategorieSPE&quot;: &quot;linkedin&quot;, &quot;customIDSPE&quot;: &quot;981330&quot;, &quot;customActionSPE&quot;: &quot;share&quot;, &quot;customSiteNameSPE&quot;: &quot;sport24.com&quot;, &quot;event&quot;: &quot;customEventBUSPE&quot;}"
+        ></i></a></li></ul></div><span class="s24-popover__arrow"></span></div></div></div></div></li>                            </ul>
+            </div>
+
+            <div class="s24-nav-art s24-nav-art__img-hidden">
+                                            <div class="s24-nav-art__container s24-nav-art__container--prev">
+                <a href="/football/coupe-du-monde/2014-bresil/fil-info/lugano-manquera-l-angleterre-700231" class="s24-nav-art__item s24-nav-art__prev">
+                    <i class="s24-icon-angle-left"></i>
+                </a>
+                <div class="s24-nav-art__article s24-nav-art__article--prev">
+                                        <div class="s24-nav-art__text">
+                        <span class="s24-nav-art__subtitle">Article précédent</span>
+                        <div class="s24-nav-art__title">
+                            <a href="/football/coupe-du-monde/2014-bresil/fil-info/lugano-manquera-l-angleterre-700231">Lugano manquera l&#039;Angleterre</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                            <div class="s24-nav-art__container s24-nav-art__container--next">
+                <a href="/football/coupe-du-monde/2014-bresil/fil-info/xavi-et-pique-sur-le-banc-700244" class="s24-nav-art__item s24-nav-art__next">
+                    <i class="s24-icon-angle-right"></i>
+                </a>
+                <div class="s24-nav-art__article s24-nav-art__article--next">
+                                        <div class="s24-nav-art__text">
+                        <span class="s24-nav-art__subtitle">Article suivant</span>
+                        <div class="s24-nav-art__title">
+                            <a href="/football/coupe-du-monde/2014-bresil/fil-info/xavi-et-pique-sur-le-banc-700244">Xavi et Piqué sur le banc</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            </div>
+
+        <a class="s24-back-top" href="#s24-top"><i class="s24-icon-angle-up"></i></a>    </div>
+    <div class="s24-flash">
+        <div class="s24-flash__wrapper">
             
+    
+                                            <div  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">23h27</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/les-u17-s-imposent-5-1-en-belgique-sur-un-quintuple-de-gouiri-844268">Foot, EdF : Les U17 s&#039;imposent 5-1 en Belgique, sur un quintuplé de Gouiri</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">20h59</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/l-unfp-tacle-kanner-796496">Foot, EdF : L&#039;UNFP tacle l&#039;intervention de Patrick Kanner </a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">09h51</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/griezmann-si-on-ne-va-pas-au-bout-ce-sera-un-echec-789455">Football, EdF : Griezmann : «Si on ne va pas au bout, ce sera un échec»</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">08h52</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/lloris-benzema-on-espere-qu-il-reviendra-le-plus-vite-possible-783215">Foot : Lloris: «Benzema ? On espère qu’il reviendra le plus vite possible»</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">18h09</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/deschamps-va-discuter-du-cas-henry-725677">Foot, EdF : Deschamps va discuter du cas Henry</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">20h04</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/lacazette-titularise-722515">Foot, EdF : Lacazette titularisé </a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">19h01</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/choc-sans-gravite-pour-gignac-722116">Foot, EdF : Choc sans gravité pour Gignac</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">16h03</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/deux-amicaux-pour-les-bleues-718428">Foot, EdF (F) : Deux amicaux pour les Bleues</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">19h56</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/le-sans-faute-des-bleues-714302">Foot, EdF (F) : Le sans faute des Bleues</a>
+            </span>
+        </div>
+    
+                                            <div  style="display: none;"  class="s24-flash__content">
+            <span class="s24-flash__title">Flash</span>
+            <span class="s24-flash__hour">15h08</span>
+            <span class="s24-flash__text">
+                <a href="/football/coupe-du-monde/2014-bresil/fil-info/kramer-ne-se-rappellera-jamais-711710">Foot, CM 2014  : Kramer ne se rappellera jamais </a>
+            </span>
+        </div>
+    
+                            <a class="s24-flash__link" href="/l-integrale?subTree=807402&amp;searchType=news">Tous les flashes <i class="s24-icon-angle-right"></i></a>
+                    </div>
+    </div>
+
+                            <div class="s24-banner-sud">
+                                        <div id="mban_btf"></div>
+                </div>
+                <script>
+    var reg = new RegExp("^/basket");
+    if(reg.test(window.location.pathname))
+    {
+        (function(){
+            var e=document.createElement('script');
+            e.async=true; e.type='text/javascript';
+            e.src=document.location.protocol + "//linicom.co.uk/links/convert_2772.js";
+            var me = document.getElementsByTagName('script')[0];
+            me.parentNode.insertBefore(e, me);
+        })();
+    } else {
+        (function(){
+            var e=document.createElement('script');
+            e.async=true;
+            e.type='text/javascript';
+            e.src=document.location.protocol + "//linicom.co.uk/links/convert_2103.js";
+            var me = document.getElementsByTagName('script')[0];
+            me.parentNode.insertBefore(e, me);
+        })();
+    }
+</script>
+            
+            
+                            <footer id="fig-footer" class="figh figh-footer">
+    <ul class="figh-footer__list">
+                <li class="figh-footer__item"  data-id="19277">
+            <a class="figh-footer__link"
+               href="/pages/site_map.html"
+                target="_blank" title="Plan du site">Plan du site</a>
         </li>
-        <li><script src="//platform.linkedin.com/in.js" type="text/javascript"></script><script type="IN/Share"></script></li>
-    </ul>
-</section><!-- ESI-END -->
-            			
-<p>Cristiano Ronaldo a quitté l’entraînement de la sélection portugaise plus tôt que ses coéquipiers ce mercredi. L’attaquant du Real Madrid a rejoint les vestiaires avec une poche de glace sur un genou, comme il l’a déjà fait à plusieurs reprises depuis son arrivée au Brésil.</p><p><i><b>Les statistiques du Portugal en Coupe du monde :</b></i></p><iframe src="http://sport24.lefigaro.fr/foot-center/coupe-du-monde/embed.html#/nation/portugal/historique/parcours" frameborder="0" width="500" height="421"></iframe>                         
-            <div class="OUTBRAIN" data-src="http://sport24.lefigaro.fr/football/coupe_du_monde/2014_bresil/fil_info/ronaldo_ecourte_l_entrainement_700221" data-widget-id="AR_2" data-ob-template="sport24fr" ></div>
-            <script type="text/javascript" async="async" src="http://widgets.outbrain.com/outbrain.js"></script>
-            <div class="OUTBRAIN" data-src="http://sport24.lefigaro.fr/football/coupe_du_monde/2014_bresil/fil_info/ronaldo_ecourte_l_entrainement_700221" data-widget-id="AR_3" data-ob-template="sport24fr" ></div>
-            
-            <div id="mb_container"></div>
-            <div id="mb_video_sponso"></div>
-            
-                <script type="text/javascript">
-                    (function(){
-                        var sc = document.createElement('script');
-                        sc.src = 'http://player.mediabong.com/se/s24/detect/821.js';
-                        sc.type = 'text/javascript';
-                        sc.async = true;
-                        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sc, s);
-                    })();
-                </script>
-            
-		</article>
-		
-			</section>
-	<div class="grid_2">
-		<span class="separateur"></span>
-											<!-- ESI-START called [/layout/set/esi/content/view/pubIrec/822050] -->	<!--
-        ESI Generated : 14:39 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubIrec/807404] -->	<!--
-        ESI Generated : 16:54 27 août 2015
-        TTL : 
--->
-
-	<!-- ESI-START called [/layout/set/esi/content/view/pubIrec/807402] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubIrec/543113] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubIrec/59] -->	<!--
-        ESI Generated : 17:08 27 août 2015
-        TTL : 
--->
-
-			<div class="pub_pave">
-			<div class="tag_pub_pave">
-				<!-- PAVE ATF - FOOTBALL 300x600 (Half Page) -->
-<script type="text/javascript" src="//ad.adxcore.com/adjs_r.php?what=zone:139262&inf=no"></script>
-			</div>
-			<img class="mention_pub_pave" src="/extension/sport24/design/site/images/mention_pub_pave.jpg" alt="" />
-			<div style="clear:both;"></div>
-		</div>
-	<!-- ESI-END -->
-	<!-- ESI-END -->
-	<!-- ESI-END --><!-- ESI-END -->
-	<!-- ESI-END -->
-							<span class="separateur"></span>		
-		<!-- ESI-START called [/layout/set/esi/content/view/filinfo/807402/offset/1] -->	<!--
-        ESI Generated : 13:32 27 août 2015
-        TTL : 
--->
-
-	
-
-    	<section class="fil_info">
-		<span class="tetiere tetiere_flash">LE FLASH</span>
-		<select id="listsport">
-			<option value="2">Tous sports</option>
-																													<option value="474819">Athlenergy</option>
-                																													<option value="282">Athlétisme</option>
-                																													<option value="220">Auto/Moto</option>
-                																													<option value="149">Basket</option>
-                																													<option value="288">Boxe</option>
-                																													<option value="197">Cyclisme</option>
-                																													<option value="664776">Endurance</option>
-                																													<option value="831911">Equitation</option>
-                																													<option value="289">Escrime</option>
-                																													<option value="59">Football</option>
-                																													<option value="231">Formule 1</option>
-                																													<option value="225060">Free zone</option>
-                																													<option value="534">Golf</option>
-                																													<option value="267">Handball</option>
-                																													<option value="739675">Handisport</option>
-                																													<option value="290">Hockey/NHL</option>
-                																													<option value="151235">Jeux Olympiques</option>
-                																													<option value="2572">Judo</option>
-                																													<option value="225">Moto</option>
-                																													<option value="292">Natation</option>
-                																													<option value="221">Rallye</option>
-                																													<option value="361240">Red Bull Air Race</option>
-                																													<option value="590603">Red Bull Cliff Diving</option>
-                																													<option value="168">Rugby</option>
-                																													<option value="293">Sports d'hiver</option>
-                																													<option value="291">Sports US</option>
-                																													<option value="117">Tennis</option>
-                																													<option value="535">Voile</option>
-                										<option value="807402" selected="selected">2014-Brésil</option>
-					</select>
-		<ol class="listeinfo">
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/le-graet-a-pris-sa-decision-pour-2016-757460" class="texte_2 ">
-					<time>
-																		25/06
-																</time>Foot, FFF : Le Graët a pris sa décision pour 2016
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/knysna-5-ans-apres-755191" class="texte_2 ">
-					<time>
-																		12/06
-																</time>Foot, EdF : Knysna, 5 ans après
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/france-maroc-en-finale-a-toulon-753788" class="texte_2 ">
-					<time>
-																		05/06
-																</time>Foot : France-Maroc en finale à Toulon
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/les-u19-qualifies-pour-l-euro-744031" class="texte_2 ">
-					<time>
-																		31/03
-																</time>Foot, U19 : Les U19 qualifiés pour l'Euro
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/l-hommage-de-benzema-a-henry-743169" class="texte_2 ">
-					<time>
-																		25/03
-																</time>Foot, EdF : L’hommage de Benzema à Henry
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/platini-et-le-bresil-743035" class="texte_2 ">
-					<time>
-																		24/03
-																</time>Foot, EdF : Platini et le Brésil
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/lloris-forfait-costil-appele-742649" class="texte_2  important ">
-					<time>
-																		21/03
-																</time>Foot, EdF : Lloris forfait, Costil appelé
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/deux-amicaux-pour-les-espoirs-739762" class="texte_2 ">
-					<time>
-																		02/03
-																</time>Foot, EdF : Deux amicaux pour les Espoirs
-				</a>
-			</li>
-															<li>
-				<a href="/football/coupe-du-monde/2014-bresil/equipe-de-france/fil-info/la-liste-pour-le-bresil-le-19-mars-739720" class="texte_2 ">
-					<time>
-																		02/03
-																</time>Foot, EdF : La liste pour le Brésil le 19 mars
-				</a>
-			</li>
-				</ol>
-		<div class="boutons_filinfo">
-			<a role="button" class="bouton_large bouton_bleu plus_infos" href="/Lintegrale/(filter)/depeche/(sport)/807402">PLUS D'INFOS</a>
-			<a role="button" class="bouton_large bouton_bleu rss" href="/rssfeeds/sport24-accueil.xml"><img src="/extension/sport24/design/site/images/picto_rss.png" alt="Flux RSS" title="Abonnez-vous aux flux sport24" class="picto_rss"/>RSS</a>
-			<input name="offset" id="offset" value=1 type="hidden" />
-			<input name="max" id="max" value=5 type="hidden" />
-			<span class="pages">1/5</span>
-			<input type="hidden" value="807402" id="ContentFillInfosSportCompetID" />
-			<a role="button" href="javascript:void(0)" class="bouton_large bouton_blanc btprec_single_disabled b1"></a>
-			<a role="button" value="2" title="Page suivante" class="bouton_large bouton_bleu btsuiv_single" href="javascript:void(0)"></a>
-		</div>
-	</section><!-- ESI-END -->
-			<span class="separateur"></span>
-    <iframe src="http://assets5.lefigaro.fr/assets-components/verticales/le-guide/index-sport24-flash.html" height="272" width="322" style="border:0;"></iframe>        						<!-- ESI-START called [/layout/set/esi/content/view/pubIrec2/822050] -->	<!--
-        ESI Generated : 14:39 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubIrec2/807404] -->	<!--
-        ESI Generated : 16:54 27 août 2015
-        TTL : 
--->
-
-	<!-- ESI-START called [/layout/set/esi/content/view/pubIrec2/807402] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubIrec2/543113] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubIrec2/59] -->	<!--
-        ESI Generated : 17:08 27 août 2015
-        TTL : 
--->
-
-			<div class="tag_pub_pave">
-			<!-- PAVE BTF - FOOTBALL 300x600 (Half Page) -->
-<script type="text/javascript" src="//ad.adxcore.com/adjs_r.php?what=zone:139261&inf=no"></script>
-		</div>
-		<img class="mention_pub_pave" src="/extension/sport24/design/site/images/mention_pub_pave.jpg" alt="" />
-	<!-- ESI-END -->
-	<!-- ESI-END -->
-	<!-- ESI-END --><!-- ESI-END -->
-	<!-- ESI-END -->
-				</div>
-</section>
-
-			                            
-                						<!-- ESI-START called [/layout/set/esi/content/view/pubSud/822050] -->	<!--
-        ESI Generated : 14:39 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubSud/807404] -->	<!--
-        ESI Generated : 16:54 27 août 2015
-        TTL : 
--->
-
-	<!-- ESI-START called [/layout/set/esi/content/view/pubSud/807402] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubSud/543113] -->	<!--
-        ESI Generated : 16:02 27 août 2015
-        TTL : 
--->
-
-			<!-- ESI-START called [/layout/set/esi/content/view/pubSud/59] -->	<!--
-        ESI Generated : 17:08 27 août 2015
-        TTL : 
--->
-
-			<section class="pub_banner">
-			<!-- MEGABAN BTF - FOOTBALL  -->
-<script type="text/javascript" src="//ad.adxcore.com/adjs_r.php?what=zone:139264&inf=no"></script>
-		</section>
-	<!-- ESI-END -->
-	<!-- ESI-END -->
-	<!-- ESI-END --><!-- ESI-END -->
-	<!-- ESI-END -->
-			            
-            		</section>
-		<footer id="footer">
-	<ul>
-		<li><a href="/pages/site_map.html">PLAN DU SITE</a></li>
-        <li ><a href="/pages/mentions.html">MENTIONS LEGALES</a></li>
-        <li><a href="/pages/cgu.html">CHARTE</a></li>
-        <li><a href="http://boutique.lefigaro.fr/cgv"|ezurl()>CGV</a></li>
-        <li><a href="/pages/cookies.html">COOKIES</a></li>
-        <li ><a href="/pages/recrutement.html">RECRUTEMENT</a></li>
-        <li class="noborder" ><a href="mailto:contact@sport24.com">CONTACTEZ-NOUS</a></li>
-	</ul>
+                <li class="figh-footer__item"  data-id="19284">
+            <a class="figh-footer__link"
+               href="/pages/mentions.html"
+                target="_blank" title="Mentions l&eacute;gales">Mentions l&eacute;gales</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19286">
+            <a class="figh-footer__link"
+               href="/pages/cgu.html"
+                target="_blank" title="Charte">Charte</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19278">
+            <a class="figh-footer__link"
+               href="http://boutique.lefigaro.fr/cgv"
+                target="_blank" title="CGV">CGV</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19279">
+            <a class="figh-footer__link"
+               href="/pages/cookies.html"
+                target="_blank" title="Cookie">Cookie</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19280">
+            <a class="figh-footer__link"
+               href="http://plus.lefigaro.fr/aide"
+                target="_blank" title="FAQ">FAQ</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19282">
+            <a class="figh-footer__link"
+               href="http://boutique.lefigaro.fr/rayon/4-abonnement/#xtor=AD-105"
+                target="_blank" title="Abonnements">Abonnements</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19285">
+            <a class="figh-footer__link"
+               href="http://www.figaromedias.fr/"
+                target="_blank" title="Publicit&eacute;">Publicit&eacute;</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19287">
+            <a class="figh-footer__link"
+               href="https://codespromo.lefigaro.fr/"
+                target="_blank" title="Codes promo">Codes promo</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19283">
+            <a class="figh-footer__link"
+               href="/pages/recrutement.html"
+                target="_blank" title="Recrutement">Recrutement</a>
+        </li>
+                <li class="figh-footer__item"  data-id="19281">
+            <a class="figh-footer__link"
+               href="mailto:contact@sport24.com"
+                target="_blank" title="Contact">Contact</a>
+        </li>
+            </ul>
 </footer>
-<script type="text/javascript" src="/livescore/js/menu.js" ></script>
-<script type="text/javascript" src="/livescore/js/home.js"></script>
-<!--Patch Brightove IE8-->
-<!--[if IE 8]><script>$('*[id^="_containermyExperience"]').css('display', 'block');</script><![endif]-->		<div id="tranche_livescore">
-	<div class="bandeau">
-		<div class="onglet">
-			<div class="bdup" title="Ouvrir">
-				<img src="/livescore/img/bdup.gif" alt="" />
-			</div>
-			<img src="/livescore/img/logoBarre.png" class="logoBarre" alt="livescore">
-		</div>
-		<div class="tiroir">
-			<div class="nav">
-				<div class="bddown" title="Réduire">
-					<img src="/livescore/img/bddown.gif" alt="" />
-				</div>
-				<img src="/livescore/img/logoBarre.png" class="logoBarre" alt="livescore">
-				<select name="sport">
-					<option value="" selected="selected">Tous les sports</option>
-					<option value="57" >Football</option><option value="230" >Formule 1</option><option value="224" >Moto</option><option value="167" >Rugby</option><option value="115" >Tennis</option><option value="267" >Handball</option><option value="147" >Basket</option><option value="196" >Cyclisme</option><option value="220" >Rallye</option>
-				</select>
-			</div>
-			<div class="scrollbar">
-				<img src="/livescore/img/flvGhe.gif" class="minus" alt="" />
-				<img src="/livescore/img/flvDte.gif" class="plus" alt="" />
-			</div>
-			<div class="scroll">
-				
-				<div class="liste"> 
-					<div class="case bleu ">
-						<div>
-							<span class="titrSport">Football - Ligue des champions</span>
-							<span class="sport">PARTIZAN</span>
-							<span class="score">
-								2 
-							</span>
-							<span class="sport">FC BATE</span>
-							<span class="score">
-								1 
-							</span>
-						</div>
-						<a href="/livescore/football/ligue-des-champions/2015-2016/barrages-retour/partizan-fc-bate">
-							 
-							<span class="trans">TERMINÉ</span>
-							<span>REVIVEZ LE LIVE</span>
-						</a>
-						
-					</div><div class="case bleu ">
-						<div>
-							<span class="titrSport">Football - Ligue des champions</span>
-							<span class="sport">CSKA MOSCOU</span>
-							<span class="score">
-								3 
-							</span>
-							<span class="sport">SPORTING</span>
-							<span class="score">
-								1 
-							</span>
-						</div>
-						<a href="/livescore/football/ligue-des-champions/2015-2016/barrages-retour/cska-moscou-sporting">
-							 
-							<span class="trans">TERMINÉ</span>
-							<span>REVIVEZ LE LIVE</span>
-						</a>
-						
-					</div><div class="case bleu ">
-						<div>
-							<span class="titrSport">Football - Ligue des champions</span>
-							<span class="sport">APOEL</span>
-							<span class="score">
-								1 
-							</span>
-							<span class="sport">ASTANA</span>
-							<span class="score">
-								1 
-							</span>
-						</div>
-						<a href="/livescore/football/ligue-des-champions/2015-2016/barrages-retour/apoel-astana">
-							 
-							<span class="trans">TERMINÉ</span>
-							<span>REVIVEZ LE LIVE</span>
-						</a>
-						
-					</div><div class="case bleu ">
-						<div>
-							<span class="titrSport">Football - Ligue des champions</span>
-							<span class="sport">FC BRUGES</span>
-							<span class="score">
-								0 
-							</span>
-							<span class="sport">MAN. UNITED</span>
-							<span class="score">
-								4 
-							</span>
-						</div>
-						<a href="/livescore/football/ligue-des-champions/2015-2016/barrages-retour/fc-bruges-man-united">
-							 
-							<span class="trans">TERMINÉ</span>
-							<span>REVIVEZ LE LIVE</span>
-						</a>
-						
-					</div><div class="case bleu ">
-						<div>
-							<span class="titrSport">Football - Ligue des champions</span>
-							<span class="sport">LEVERKUSEN</span>
-							<span class="score">
-								3 
-							</span>
-							<span class="sport">LAZIO ROME</span>
-							<span class="score">
-								0 
-							</span>
-						</div>
-						<a href="/livescore/football/ligue-des-champions/2015-2016/barrages-retour/leverkusen-lazio-rome">
-							 
-							<span class="trans">TERMINÉ</span>
-							<span>REVIVEZ LE LIVE</span>
-						</a>
-						
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</div>
-	</div><div class="OUTBRAIN" data-src="" data-widget-id="TR_1" data-ob-template="sport24fr" ></div>
-<script type="text/javascript">document.querySelector('.OUTBRAIN').dataset['src'] = document.location</script>
-<script type="text/javascript" src="http://widgets.outbrain.com/outbrain.js"></script>                
-<script type='text/javascript'>
-	if (!window.xtcustom) xtcustom = {}; 
-	xtsite='411571';
-	xtcustom.type='news';
+            
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.3/moment.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/hinclude/0.9.5/hinclude.js"></script>
+    <script src="/js/c2ade29.js"></script>
+
+<script src="//platform.linkedin.com/in.js" type="text/javascript"> lang: fr_FR</script>
+                                                <script>
+    if (!window.xtcustom) xtcustom = {};
+    if($(window).width() < 1000) {
+        xtsite='548945';
+    } else {
+        xtsite='411571';
+    }
+    xtcustom.type='news';
 </script>
-<script type='text/javascript' src='/extension/sport24/design/site/javascript/xtcore.js'></script>
+    <script src="/js/4bf4740.js"></script>
 <noscript><img width='1' height='1' alt='' src='http://logc111.xiti.com/hit.xiti?s=411571'></noscript>
-<script type="text/javascript">
-	var _gaq = _gaq || [];
-	_gaq.push(['_setAccount', 'UA-715796-1']);
-	_gaq.push(['_setDomainName', 'sport24.com']);
-	_gaq.push(['_trackPageview']);
-	(function(){
-    	var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-	})();
+
+<script>
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-715796-1']);
+    _gaq.push(['_setDomainName', 'sport24.com']);
+    _gaq.push(['_trackPageview']);
+    _gaq.push(['_setCustomVar',1,'adblock', typeof(window._advst_params)=='undefined' ? 'No' : 'Yes',1 ]);
+    (function(){
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
 </script>
-<script type="text/javascript">
+
+<script>
     setTimeout(function(){var a=document.createElement("script");
     var b=document.getElementsByTagName("script")[0];
     a.src=document.location.protocol+"//dnn506yrbagrg.cloudfront.net/pages/scripts/0012/8793.js?"+Math.floor(new Date().getTime()/3600000);
     a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
 </script>
-<script type="text/javascript">
+<script>
     var nugg4Rubicon ="";
     var nuggrid= encodeURIComponent(top.location.href);
     document.write('<scr'+'ipt type=\"text/javascript\" src=\"http://lpm-lefigaro.nuggad.net/rc?nuggn=627225677&nuggsid=678661348&nuggrid='+nuggrid+'"><\/scr'+'ipt>');
 </script>
-</body>
-</html>
+
+<iframe style="height: 1px; width: 1px; border: 0px none; position: absolute; display: none; left: 0px; top: 0px; z-index: 0;" src="//cstatic.weborama.fr/iframe/customers/premium.html?idEditeur=1145&idSite=181"></iframe>                <script type='text/javascript'>
+    var _sf_async_config = _sf_async_config || {};
+    /** CONFIGURATION START **/
+    _sf_async_config.uid = 43900;     _sf_async_config.domain = 'lefigaro.fr';
+    _sf_async_config.useCanonical = true;
+    _sf_async_config.sections = 'sport24, football, coupe-du-monde, 2014-bresil, fil-info';
+    _sf_async_config.authors = 'Sport24';
+    /** CONFIGURATION END **/
+    (function() {
+        function loadChartbeat() {
+            window._sf_endpt = (new Date()).getTime();
+            var e = document.createElement('script');
+            e.setAttribute('language', 'javascript');
+            e.setAttribute('type', 'text/javascript');
+            e.setAttribute('src', '//static.chartbeat.com/js/chartbeat.js');
+            document.body.appendChild(e);
+        }
+        var oldonload = window.onload;
+        window.onload = (typeof window.onload != 'function') ?
+                loadChartbeat : function() {
+            oldonload();
+            loadChartbeat();
+        };
+    })();
+</script>
+                
+
+<script>
+    
+    // isMobile (detection)
+    !function(a){var b=/iPhone/i,c=/iPod/i,d=/iPad/i,e=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,f=/Android/i,g=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,h=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,i=/IEMobile/i,j=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,k=/BlackBerry/i,l=/BB10/i,m=/Opera Mini/i,n=/(CriOS|Chrome)(?=.*\bMobile\b)/i,o=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,p=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i"),q=function(a,b){return a.test(b)},r=function(a){var r=a||navigator.userAgent,s=r.split("[FBAN");return"undefined"!=typeof s[1]&&(r=s[0]),this.apple={phone:q(b,r),ipod:q(c,r),tablet:!q(b,r)&&q(d,r),device:q(b,r)||q(c,r)||q(d,r)},this.amazon={phone:q(g,r),tablet:!q(g,r)&&q(h,r),device:q(g,r)||q(h,r)},this.android={phone:q(g,r)||q(e,r),tablet:!q(g,r)&&!q(e,r)&&(q(h,r)||q(f,r)),device:q(g,r)||q(h,r)||q(e,r)||q(f,r)},this.windows={phone:q(i,r),tablet:q(j,r),device:q(i,r)||q(j,r)},this.other={blackberry:q(k,r),blackberry10:q(l,r),opera:q(m,r),firefox:q(o,r),chrome:q(n,r),device:q(k,r)||q(l,r)||q(m,r)||q(o,r)||q(n,r)},this.seven_inch=q(p,r),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window?this:void 0},s=function(){var a=new r;return a.Class=r,a};"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=r:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=s():"function"==typeof define&&define.amd?define("isMobile",[],a.isMobile=s()):a.isMobile=s()}(this);
+
+    // datalayer
+    window.universal_variable = {
+        "krux":{
+            "configuration_id":"JKtjq-Dt"
+        },
+        "device": {
+            "type": "desktop"
+        },
+        "apn": {
+            "debug": false,
+            "options": {
+                "member": 3273,
+                "keywords": {
+                    "mots-cles": "sport, football, coupe-du-monde, 2014-bresil, fil-info, ronaldo-ecourte-l-entrainement-700221",
+                    "rubrique": null,
+                    "artid": "700221",
+                    "auteur": "",
+//                    "page-payant": "0",
+                    "type": "news"
+                }
+            },
+            "tags": [
+                {
+                    "invCode": "lefigaro_sport-football-articles_mban_atf",
+                    "size": {
+                        "desktop": "[1000,300],[970,250],[1000,260],[1000,200],[1000,90],[728,90],[1000,301],[970,251],[1000,261],[1000,201],[1000,91],[728,91]",
+                        "tablette": "[1000,300],[970,250],[1000,260],[1000,200],[1000,90],[728,90],[1000,301],[970,251],[1000,261],[1000,201],[1000,91],[728,91]",
+                        "smartphone": "[320,53],[320,50],[300,50]"
+                    },
+                    "targetId": "mban_atf"
+                },
+                                {
+                    "invCode": "lefigaro_sport-football-articles_habillage",
+                    "size": {
+                        "desktop": "[1800,1000]",
+                        "tablette": "[1800,1000]",
+                        "smartphone": "[1800,1000]"
+                    },
+                    "targetId": "habillage"
+                },
+                                {
+                    "invCode": "lefigaro_sport-football-articles_intrusif",
+                    "size": {
+                        "desktop": "[1,1]",
+                        "tablette": "[1,1]",
+                        "smartphone": "[1,1]"
+                    },
+                    "targetId": "intrusif"
+                },
+                {
+                    "invCode": "lefigaro_sport-football-articles_mban_btf",
+                    "size": {
+                        "desktop": "[1000,300],[970,250],[1000,260],[1000,200],[1000,90],[728,90],[1000,304],[970,254],[1000,264],[1000,204],[1000,94],[728,94]",
+                        "tablette": "[1000,300],[970,250],[1000,260],[1000,200],[1000,90],[728,90],[1000,304],[970,254],[1000,264],[1000,204],[1000,94],[728,94]",
+                        "smartphone": "[320,53],[320,50],[300,50]"
+                    },
+                    "targetId": "mban_btf"
+                },
+                {
+                    "invCode": "lefigaro_sport-football-articles_pave_atf",
+                    "size": {
+                        "desktop": "[300,1050],[300,1000],[300,900],[300,600],[300,250],[300,1051],[300,1001],[300,901],[300,601],[300,251]",
+                        "tablette": "[300,1050],[300,1000],[300,900],[300,600],[300,250],[300,1051],[300,1001],[300,901],[300,601],[300,251]",
+                        "smartphone": "[300,250],[300,50],[320,50]"
+                    },
+                    "targetId": "pave_atf"
+                },
+                {
+                    "invCode": "lefigaro_sport-football-articles_pave_btf",
+                    "size": {
+                        "desktop": "[300,1050],[300,1000],[300,900],[300,600],[300,250],[300,1054],[300,1004],[300,904],[300,604],[300,254]",
+                        "tablette": "[300,1050],[300,1000],[300,900],[300,600],[300,250],[300,1054],[300,1004],[300,904],[300,604],[300,254]",
+                        "smartphone": "[300,250]"
+                    },
+                    "targetId": "pave_btf"
+                }
+            ]
+        }
+    };
+
+
+    // setup device with isMobile library (used by apntag)
+    universal_variable.device.type = (isMobile.phone ? "smartphone" : (isMobile.tablet ? "tablette" : "desktop"));
+</script>
+
+<script async src="http://a.f1g.fr/h/assets-components/tm/sport24.js"></script>
+<script>
+    var apntag=apntag||{}; apntag.anq=apntag.anq||[];
+    apntag.anq.push(function(){
+        apntag.onEvent('adAvailable','habillage',function(adObj){
+            if(adObj.buyerMemberId != '3273'){
+                document.getElementById("habillage").classList.add('s24-habillage-rtb');
+                document.getElementById("habillage").parentElement.classList.add('s24-habillage-parent');
+            }
+        });
+    });
+</script>
+            
+            <script src="/js/d9e880a.js"></script>
+        <!--Visual Revenue Reader Response Tracking Script (v6) -->
+    <script type="text/javascript">
+        var _vrq = _vrq || [];
+        _vrq.push(['id', 802]);
+        _vrq.push(['automate', false]);
+        _vrq.push(['track', function(){}]);
+        (function(d, a){
+            var s = d.createElement(a),
+                    x = d.getElementsByTagName(a)[0];
+            s.async = true;
+            s.src = 'http://a.visualrevenue.com/vrs.js';
+            x.parentNode.insertBefore(s, x);
+        })(document, 'script');
+    </script>
+    <!-- End of VR RR Tracking Script - All rights reserved -->
+        <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"d067c0e657","applicationID":"11480914","transactionName":"ZQQAbBAEXxYHVEReDVxOI1sWDF4LSVJKaBdADQNUCwRC","queueTime":0,"applicationTime":244,"atts":"SUMDGlgeTBg=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+        </html>
+    

--- a/test_data/murray_senate_gov.html
+++ b/test_data/murray_senate_gov.html
@@ -1,67 +1,66 @@
 
-
-  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 
 <head>
-  <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-  <title>News Releases - Newsroom - Murray & Cantwell Applaud Advancement of Key Provision to Help Central Kitsap School District   - United States Senator Patty Murray</title>
-  <meta name="Keywords" content="" />
-  <meta name="Description" content="Official website of U.S. Senator Patty Murray, Senator for Washington State, Democratic Party" />
+	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+	<title>News Releases - Newsroom - Murray & Cantwell Applaud Advancement of Key Provision to Help Central Kitsap School District   - United States Senator Patty Murray</title>
+	<meta name="Keywords" content="" />
+	<meta name="Description" content="Official website of U.S. Senator Patty Murray, Senator for Washington State, Democratic Party" />
 
-  <meta property="og:description" content="Official website of U.S. Senator Patty Murray, Senator for Washington State, Democratic Party" />
+	<meta property="og:description" content="Official website of U.S. Senator Patty Murray, Senator for Washington State, Democratic Party" />
 
-  
-  
-  <meta name="date" content="2015-07-16" />
-  
+	
+	
+	<meta name="date" content="2015-07-16" />
+	
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  
-  <link rel="stylesheet" type="text/css" href="/public/_resources/stylesheets/core.css" media="all" />
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/uni-form.css" media="all" />
-  <!--[if lte ie 6]>
-  <style type="text/css" media="screen">
-  .uniForm,
-  .uniForm fieldset,
-  .uniForm .ctrlHolder,
-  .uniForm .formHint{ /* Trigger hasLayout, move to your IE specific stylesheet if possible */
-  zoom:1;
-  }
-  </style>
-  <![endif]-->
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/default.css" media="all" />
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/template.css" media="screen" />
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/everything_else.css" media="all"  />
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/override.css?cb=1" media="screen"  />
-  
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/home.css" media="screen" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	
+	<link rel="stylesheet" type="text/css" href="/public/_resources/stylesheets/core.css" media="all" />
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/uni-form.css" media="all" />
+	<!--[if lte ie 6]>
+	<style type="text/css" media="screen">
+	.uniForm,
+	.uniForm fieldset,
+	.uniForm .ctrlHolder,
+	.uniForm .formHint{ /* Trigger hasLayout, move to your IE specific stylesheet if possible */
+	zoom:1;
+	}
+	</style>
+	<![endif]-->
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/default.css" media="all" />
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/template.css" media="screen" />
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/everything_else.css" media="all"  />
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/override.css?cb=1" media="screen"  />
+	
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/home.css" media="screen" />
 
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/home-20150414.css" media="screen" />
-  
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/print.css" media="print" />
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/css/mobile.css" media="handheld" />
-  
-  <link rel="stylesheet" type="text/css" href="http://www.murray.senate.gov/public/vendor/_skins/murray/js/fancybox/jquery.fancybox-1.3.1.css" media="screen" />
-  
-  <link rel="shortcut icon" href="vendor/_skins/murray/images/favicon.ico" />
-  
-  <link rel="alternate" type="application/rss+xml" href="http://www.murray.senate.gov/public/?a=RSS.Feed" title="Latest Posts" />
-  
-  <!-- SWF-Object -->
-  <script type="text/javascript" src="/public/_resources/jscripts/swfobject-2.1.js"></script>
-  
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/jquery-1.4.2.min.js"></script>
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/underscore-0.3.3.min.js"></script>
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/uni-form.jquery.js"></script>
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/TabWidget.js"></script>
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/RotatingTabWidget.js"></script>
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/default.js"></script>
-  <script type="text/javascript" src="http://www.murray.senate.gov/public/vendor/_skins/murray/js/fancybox/jquery.fancybox-1.3.1.pack.js"></script>
-  
-  <script type="text/javascript" src="/public/_resources/jscripts/detectmobile.js"></script>
-  
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/home-20150414.css" media="screen" />
+	
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/print.css" media="print" />
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/css/mobile.css" media="handheld" />
+	
+	<link rel="stylesheet" type="text/css" href="https://www.murray.senate.gov/public/vendor/_skins/murray/js/fancybox/jquery.fancybox-1.3.1.css" media="screen" />
+	
+	<link rel="shortcut icon" href="vendor/_skins/murray/images/favicon.ico" />
+	
+	<link rel="alternate" type="application/rss+xml" href="http://www.murray.senate.gov/public/?a=RSS.Feed" title="Latest Posts" />
+	
+	<!-- SWF-Object -->
+	<script type="text/javascript" src="/public/_resources/jscripts/swfobject-2.1.js"></script>
+	
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/jquery-1.4.2.min.js"></script>
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/underscore-0.3.3.min.js"></script>
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/uni-form.jquery.js"></script>
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/TabWidget.js"></script>
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/RotatingTabWidget.js"></script>
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/default.js"></script>
+	<script type="text/javascript" src="https://www.murray.senate.gov/public/vendor/_skins/murray/js/fancybox/jquery.fancybox-1.3.1.pack.js"></script>
+	
+	<script type="text/javascript" src="/public/_resources/jscripts/detectmobile.js"></script>
+	
 
 <script type="text/javascript">
 try {
@@ -72,254 +71,274 @@ detectmobile.process();
 </script>
 
 
-  
-  <!-- AddThis Button BEGIN -->
-  <script type="text/javascript">var addthis_pub="4a13a1f31790c388";</script>
-  
-  
-  
-  
-  
-    <script type="text/javascript">
-     
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', ' UA-16142309-2']);
-      _gaq.push(['_trackPageview']);
-     
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-     
-    </script>
-    
-    
-  
+	
+	<!-- AddThis Button BEGIN -->
+	<script type="text/javascript">var addthis_pub="4a13a1f31790c388";</script>
+	
+	
+	
+	
+	
+		<script type="text/javascript">
+		 
+		  var _gaq = _gaq || [];
+		  _gaq.push(['_setAccount', ' UA-16142309-2']);
+		  _gaq.push(['_trackPageview']);
+		 
+		  (function() {
+		    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+		    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+		    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+		  })();
+		 
+		</script>
+		
+		
+	
 
 </head>
 
 <body class="page_newsreleases fuseaction_pages_view circuit_circuit fuse_fuse locale_en_us">
 
-<div class="pagesection_newsroom isHighBandwidth seed_3">
+<div class="pagesection_newsroom isHighBandwidth seed_7">
 <div class="rootContainer">
-  <div id="head">
-    <div class="templateWrapper">
-      <div id="searchBar">   
-        <div id="searchForm">
-          <form action="/public/">
-            <input type="hidden" name="p" value="Search" />
-            <input type="hidden" name="num" value="10" />
-            <input type="hidden" name="filter" value="0" />
-            <input type="text" class="text" name="q" value="Search" />
-            <input type="submit" class="submit" value="Go" />
-          </form>
-        </div>
-        <div id="socialLinks">
-          <a id="rssLink" href="http://www.murray.senate.gov/public/?a=RSS.Feed">RSS</a>
-          <a id="youtubeLink" href="http://www.youtube.com/user/SenatorPattyMurray">Youtube</a>
-          <a id="twitterLink" href="http://twitter.com/#!/pattymurray">Twitter</a>
-          <a id="googlePlusLink" href="https://plus.google.com/103993090990526286287" rel="publisher">Google+</a>
-          <a id="instagramLink" href="http://instagram.com/senpattymurray">Instagram</a>
-          
-        </div>
-        <div id="topLinks">
-          <a href="http://www.murray.senate.gov/public/index.cfm/getemailupdates">Get Email Updates</a>
-          &nbsp;&nbsp;|&nbsp;&nbsp;
-          <a href="http://www.murray.senate.gov/public/index.cfm/lowbandwidth/newsreleases?ContentRecord_id=28da79eb-bca4-421e-9358-cec1c064def0">Low Bandwidth</a> 
-          &nbsp;&nbsp;|
-        </div>
-      </div>
-    
-      <div id="headerWrapper">
-        <h1 id="header"><a href="http://www.murray.senate.gov/public/index.cfm/home">United States Senator Patty Murray</a></h1>
-      </div>
-      
-    </div>
-  </div>
-  
-  <div id="body">
-    <div id="bodyOuterWrapper">
-      <div class="templateWrapper">
-        <div id="nav">
-          
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-          <ul>
-            <li id="navHome"><a href="http://www.murray.senate.gov/public/index.cfm/home">Home</a></li>
-            
-              <li id="navAboutPatty">
-                <a href="http://www.murray.senate.gov/public/index.cfm/aboutpatty">About Patty</a>
-                
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-                <ul><li class="first"><a href="http://www.murray.senate.gov/public/index.cfm/biography">Biography</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/committeeassignments1">Committee Assignments</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/meetpattyforcoffee">Meet Patty for Coffee</a></li><li class="last"><a href="http://www.murray.senate.gov/public/index.cfm/officialphotos">Official Photos</a></li></ul>
-                
-              </li>
-            
-              <li id="navServices">
-                <a href="http://www.murray.senate.gov/public/index.cfm/services">Services</a>
-                
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-                <ul><li class="first"><a href="http://www.murray.senate.gov/public/index.cfm/requestassistance">Request Assistance</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/visitingwashingtondc">Visiting Washington D.C.</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/orderinganamericanflag">Ordering an American Flag</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/internships">Internships</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/weeklycoffee">Weekly Coffee with Senator Murray</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/grantgateway">Grant Gateway</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/militaryserviceacademynominations">Military Service Academy Nominations</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/senatepageprogram">Senate Page Program</a></li><li class="last"><a href="http://www.murray.senate.gov/public/index.cfm/washingtonresources">Washington Resources</a></li></ul>
-                
-              </li>
-            
-              <li class="current" id="navNewsroom">
-                <a href="http://www.murray.senate.gov/public/index.cfm/newsroom">Newsroom</a>
-                
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-                <ul><li class="selected first"><a href="http://www.murray.senate.gov/public/index.cfm/newsreleases">News Releases</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/pattyinnews">Patty in the News</a></li><li class="last"><a href="http://www.murray.senate.gov/public/index.cfm/multimediagallery">Multimedia</a></li></ul>
-                
-              </li>
-            
-              <li id="navIssues">
-                <a href="http://www.murray.senate.gov/public/index.cfm/issues">Issues</a>
-                
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-              </li>
-            
-              <li id="navLegislation">
-                <a href="http://www.murray.senate.gov/public/index.cfm/legislation">Legislation</a>
-                
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-                <ul><li class="first"><a href="http://www.murray.senate.gov/public/index.cfm/sponsoredlegislation">Sponsored Legislation</a></li><li><a href="http://www.murray.senate.gov/public/index.cfm/cosponsoredlegislation">Cosponsored Legislation</a></li><li class="last"><a href="http://www.murray.senate.gov/public/index.cfm/votingrecord">Voting Record</a></li></ul>
-                
-              </li>
-            
-            <div class="clear"></div>
-          </ul>
-        </div>
-  
-        <a name="Top"></a>
-        
+	<div id="head">
+		<div class="templateWrapper">
+			<div id="searchBar">   
+				<div id="searchForm">
+					<form action="https://www.murray.senate.gov/public/index.cfm/search">
+						<input type="hidden" name="p" value="Search" />
+						<input type="hidden" name="num" value="10" />
+						<input type="hidden" name="filter" value="0" />
+						<input type="text" class="text" name="q" value="Search" />
+						<input type="submit" class="submit" value="Go" />
+					</form>
+				</div>
+				<div id="socialLinks">
+					<a id="rssLink" href="http://www.murray.senate.gov/public/?a=RSS.Feed">RSS</a>
+					<a id="youtubeLink" href="http://www.youtube.com/user/SenatorPattyMurray">Youtube</a>
+					<a id="twitterLink" href="http://twitter.com/#!/pattymurray">Twitter</a>
+					<a id="googlePlusLink" href="https://plus.google.com/103993090990526286287" rel="publisher">Google+</a>
+					<a id="instagramLink" href="http://instagram.com/senpattymurray">Instagram</a>
+					
+				</div>
+				<div id="topLinks">
+					<a href="https://www.murray.senate.gov/public/index.cfm/getemailupdates">Get Email Updates</a>
+					&nbsp;&nbsp;|&nbsp;&nbsp;
+					<a href="http://www.murray.senate.gov/public/index.cfm/lowbandwidth/newsreleases?ContentRecord_id=28da79eb-bca4-421e-9358-cec1c064def0">Low Bandwidth</a> 
+					&nbsp;&nbsp;|
+				</div>
+			</div>
+		
+			<div id="headerWrapper">
+				<h1 id="header"><a href="https://www.murray.senate.gov/public/index.cfm/home">United States Senator Patty Murray</a></h1>
+			</div>
+			
+		</div>
+	</div>
+	
+	<div id="body">
+		<div id="bodyOuterWrapper">
+			<div class="templateWrapper">
+				<div id="nav">
+					
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+					<ul>
+						<li id="navHome"><a href="https://www.murray.senate.gov/public/index.cfm/home">Home</a></li>
+						
+							<li id="navAboutPatty">
+								<a href="https://www.murray.senate.gov/public/index.cfm/aboutpatty">About Patty</a>
+								
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+								<ul><li class="first"><a href="https://www.murray.senate.gov/public/index.cfm/biography">Biography</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/committeeassignments1">Committee Assignments</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/meetpattyforcoffee">Meet Patty for Coffee</a></li><li class="last"><a href="https://www.murray.senate.gov/public/index.cfm/officialphotos">Official Photos</a></li></ul>
+								
+							</li>
+						
+							<li id="navServices">
+								<a href="https://www.murray.senate.gov/public/index.cfm/services">Services</a>
+								
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+								<ul><li class="first"><a href="https://www.murray.senate.gov/public/index.cfm/requestassistance">Request Assistance</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/visitingwashingtondc">Visiting Washington D.C.</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/orderinganamericanflag">Ordering an American Flag</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/internships">Internships</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/weeklycoffee">Weekly Coffee with Senator Murray</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/grantgateway">Grant Gateway</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/militaryserviceacademynominations">Military Service Academy Nominations</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/senatepageprogram">Senate Page Program</a></li><li class="last"><a href="https://www.murray.senate.gov/public/index.cfm/washingtonresources">Washington Resources</a></li></ul>
+								
+							</li>
+						
+							<li class="current" id="navNewsroom">
+								<a href="https://www.murray.senate.gov/public/index.cfm/newsroom">Newsroom</a>
+								
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+								<ul><li class="selected first"><a href="https://www.murray.senate.gov/public/index.cfm/newsreleases">News Releases</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/pattyinnews">Patty in the News</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/multimediagallery">Multimedia</a></li><li class="last"><a href="https://www.murray.senate.gov/public/index.cfm/blog">Blog</a></li></ul>
+								
+							</li>
+						
+							<li id="navIssues">
+								<a href="https://www.murray.senate.gov/public/index.cfm/issues">Issues</a>
+								
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+								<ul><li class="first"><a href="https://www.murray.senate.gov/public/index.cfm/agriculture-and-rural-communities">Agriculture and Rural Communities</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/education-and-workforce-development">Education and Workforce Training</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/energy-environment-and-hanford">Energy, Environment, and Hanford</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/fighting-for-equal-protection-under-the-law">Fighting for Equal Protection Under the Law</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/health-care">Health Care</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/immigration">Immigration</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/jobs-and-economic-growth">Jobs and Economic Growth</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/national-security">National Security</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/seniors">Seniors</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/transportation_1">Transportation</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/tribes_2">Tribes</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/veterans-and-mil">Veterans and Military</a></li><li class="last"><a href="https://www.murray.senate.gov/public/index.cfm/women_1">Women</a></li></ul>
+								
+							</li>
+						
+							<li id="navLegislation">
+								<a href="https://www.murray.senate.gov/public/index.cfm/legislation">Legislation</a>
+								
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+								<ul><li class="first"><a href="https://www.murray.senate.gov/public/index.cfm/sponsoredlegislation">Sponsored Legislation</a></li><li><a href="https://www.murray.senate.gov/public/index.cfm/cosponsoredlegislation">Cosponsored Legislation</a></li><li class="last"><a href="https://www.murray.senate.gov/public/index.cfm/votingrecord">Voting Record</a></li></ul>
+								
+							</li>
+						
+							<li id="navtribes_1">
+								<a href="https://www.murray.senate.gov/public/index.cfm/tribes_1">Tribes</a>
+								
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+							</li>
+						
+						<div class="clear"></div>
+					</ul>
+				</div>
+	
+				<a name="Top"></a>
+				
+					<!-- replace non-SSL with SSL for internal links -->
+					
 
 <div id="copyBodyContainer">
-  <div id="copyBodyWrapper">
-    <div id="copyHeader">
-      <div class="copyBodyHeaderTitle">
-        
-        
-          <a href="http://www.murray.senate.gov/public/index.cfm/home" class="home">Home</a>
-        
-          <a href="http://www.murray.senate.gov/public/index.cfm/newsroom" class="">Newsroom</a>
-        
-          <a href="http://www.murray.senate.gov/public/index.cfm/newsreleases" class=" last">News Releases</a>
-        
-        
-      </div>
-    </div>
-    <div id="copyBody">
-      <div id="copyContainer">
-        <div id="copyBodyHeader">
-          
-          
-          <h2 class="copyHeaderTitle">News Releases</h2>
-          <div class="clear"></div>
-          
-            <div class="printerFriendly">
-              <a href="?ContentRecord_id=28da79eb-bca4-421e-9358-cec1c064def0&print=true" title="Printer Friendly"><span>Printer Friendly</span></a>
-            </div>
-          
-        </div>
-        <div id="copy" class="copy">
-          <div class="pagegroup pagegroup_posttypes odd first last">
+	<div id="copyBodyWrapper">
+		<div id="copyHeader">
+			<div class="copyBodyHeaderTitle">
+				
+				
+					<a href="https://www.murray.senate.gov/public/index.cfm/home" class="home">Home</a>
+				
+					<a href="https://www.murray.senate.gov/public/index.cfm/newsroom" class="">Newsroom</a>
+				
+					<a href="https://www.murray.senate.gov/public/index.cfm/newsreleases" class=" last">News Releases</a>
+				
+				
+			</div>
+		</div>
+		<div id="copyBody">
+			<div id="copyContainer">
+				<div id="copyBodyHeader">
+					
+					
+					<h2 class="copyHeaderTitle">News Releases</h2>
+					<div class="clear"></div>
+					
+						<div class="printerFriendly">
+							<a href="?ContentRecord_id=28da79eb-bca4-421e-9358-cec1c064def0&print=true" title="Printer Friendly"><span>Printer Friendly</span></a>
+						</div>
+					
+				</div>
+				<div id="copy" class="copy">
+					<div class="pagegroup pagegroup_posttypes odd first last">
 
-  
-    
+	
+		
 <div class="section posttypelayout_monthyear">
 
 
 
 <div class="element element_posttypes">
-  
-    
+	
+		
 
 
 
 <div class="contentrecord article">
 
-<a name="28da79eb-bca4-421e-9358-cec1c064def0"></a>
+<a name="28DA79EB-BCA4-421E-9358-CEC1C064DEF0"></a>
 
 <div class="header">
-  <h1 class="title"><a href="http://www.murray.senate.gov/public/index.cfm/newsreleases?ID=28da79eb-bca4-421e-9358-cec1c064def0">Murray & Cantwell Applaud Advancement of Key Provision to Help Central Kitsap School District  </a></h1>
-  
-  <h4 class="date">
-    
-    
-      
-    
-    <span class="month">Jul</span> <span class="day">16</span> <span class="year">2015</span></h4>
-  
-  
-  
+	<h1 class="title"><a href="https://www.murray.senate.gov/public/index.cfm/newsreleases?ID=28DA79EB-BCA4-421E-9358-CEC1C064DEF0">Murray & Cantwell Applaud Advancement of Key Provision to Help Central Kitsap School District  </a></h1>
+	
+	<h4 class="date">
+		
+		
+			
+		
+		<span class="month">Jul</span> <span class="day">16</span> <span class="year">2015</span></h4>
+	
+	
+	
 </div>
 <div class="content">
-  
-  
-  
-  
-  
-    
-    <div class="p1" style="text-align: center;"><span class="s1"><b><i>Murray&rsquo;s education bill passes Senate, which includes funding for CKSD</i></b></span></div>
+	
+	
+	
+	
+	
+		
+		<div class="p1" style="text-align: center;"><span class="s1"><b><i>Murray&rsquo;s education bill passes Senate, which includes funding for CKSD</i></b></span></div>
 <div class="p1" style="text-align: center;"><span class="s1"><b><i>&nbsp;</i></b></span></div>
 <div class="p1" style="text-align: center;"><span class="s1"><b><i>Senators will fight to make sure CKSD provision remains in final bill</i></b></span></div>
 <p class="p2"><span class="s2"><b>&nbsp;</b></span><span class="s1"><b><i>&nbsp;</i></b></span></p>
@@ -330,32 +349,32 @@ detectmobile.process();
 <p class="p1"><span class="s2">&ldquo;Central Kitsap School District needs this funding to provide its students with the educational opportunities they deserve &ndash; opportunities that were threatened by a four-year funding loss,&rdquo; <b>Senator Cantwell said</b>.&nbsp;&ldquo;It&rsquo;s time we stand by our service men and women to provide their children with the tools and services needed for a quality education, by restoring some of the funds they are eligible for under the Impact Aid program.&rdquo;</span></p>
 <p class="p4"><span class="s2">&nbsp;</span></p>
 <p class="p1"><span class="s2">Sen. Murray, the top Democrat on the Senate Health, Education, Labor, and Pensions (HELP) Committee, wrote the Every Child Achieves Act with her Republican counterpart, Sen. Lamar Alexander of Tennessee. The ECAA would replace the badly-broken No Child Left Behind law, which set ambitious goals but failed to give schools the resources they needed to help students succeed. Sen. Murray&rsquo;s bill would help ensure all students have access to a high-quality public education.</span></p>
-    
-  
+		
+	
 </div>
 
 <div class="clear"></div>
 
 <div class="footer">
-  <div class="permalink">Permalink: <a href="http://www.murray.senate.gov/public/index.cfm/2015/7/murray-cantwell-applaud-advancement-of-key-provision-to-help-central-kitsap-school-district">http://www.murray.senate.gov/public/index.cfm/2015/7/murray-cantwell-applaud-advancement-of-key-provision-to-help-central-kitsap-school-district</a></div>
-  
-  
-  
-    <div class="bookmarklet">
-      <a href="http://www.addthis.com/bookmark.php?v=20" onmouseover="return addthis_open(this, '', 'http://www.murray.senate.gov/public/index.cfm/newsreleases?ID=28da79eb-bca4-421e-9358-cec1c064def0', 'Murray & Cantwell Applaud Advancement of Key Provision to Help Central Kitsap School District   - United States Senator Patty Murray')" onmouseout="addthis_close()" onclick="return addthis_sendto()"><img src="http://s7.addthis.com/static/btn/lg-bookmark-en.gif" width="125" height="16" alt="Bookmark and Share" style="border:0"/></a><script type="text/javascript" src="http://s7.addthis.com/js/200/addthis_widget.js"></script>
-    </div>
-  
-  <div class="clear"></div>
-  
-  
+	<div class="permalink">Permalink: <a href="https://www.murray.senate.gov/public/index.cfm/2015/7/murray-cantwell-applaud-advancement-of-key-provision-to-help-central-kitsap-school-district">https://www.murray.senate.gov/public/index.cfm/2015/7/murray-cantwell-applaud-advancement-of-key-provision-to-help-central-kitsap-school-district</a></div>
+	
+	
+	
+		<div class="bookmarklet">
+			<a href="http://www.addthis.com/bookmark.php?v=20" onmouseover="return addthis_open(this, '', 'https://www.murray.senate.gov/public/index.cfm/newsreleases?ID=28DA79EB-BCA4-421E-9358-CEC1C064DEF0', 'Murray & Cantwell Applaud Advancement of Key Provision to Help Central Kitsap School District   - United States Senator Patty Murray')" onmouseout="addthis_close()" onclick="return addthis_sendto()"><img src="http://s7.addthis.com/static/btn/lg-bookmark-en.gif" width="125" height="16" alt="Bookmark and Share" style="border:0"/></a><script type="text/javascript" src="http://s7.addthis.com/js/200/addthis_widget.js"></script>
+		</div>
+	
+	<div class="clear"></div>
+	
+	
 
 
-  
-  
-  
-  
-  
-  <div class="clear"></div>
+	
+	
+	
+	
+	
+	<div class="clear"></div>
 </div>
 <div class="clear"></div>
 </div>
@@ -364,156 +383,163 @@ detectmobile.process();
 
 </div>
 </div>
-          
-        </div>
-      </div>
-    
-    
-      <div id="sidebarContainer">
-        
+					
+				</div>
+			</div>
+		
+		
+			<div id="sidebarContainer">
+				
 
 <div id="sidebar">
-  <div id="sidebarWrapper">
-    <div id="sidebarContent">
-    
-      <div id="subnav">
-        <h2>Related Links</h2>
-        <div id="subnavContent">
-          <div class="subnav subnav_pages subnav_level_12 subnav_child">
-            <ul class="subnav_root">
-            
-            
-              <li class="subnav_item odd first">
-              
-                <a href="http://www.murray.senate.gov/public/index.cfm/newsreleases" class="selected">News Releases</a>
-              
-              </li>
-            
-              <li class="subnav_item even">
-              
-                <a href="http://www.murray.senate.gov/public/index.cfm/pattyinnews" class="">Patty in the News</a>
-              
-              </li>
-            
-              <li class="subnav_item odd last">
-              
-                <a href="http://www.murray.senate.gov/public/index.cfm/multimediagallery" class="">Multimedia</a>
-              
-              </li>
-            
-            </ul>
-          </div>
-        </div>
-      </div>
-    
-    <div id="officeInformation">
-      <h2>Office Information</h2>
-      <div class="office" id="office_DC">
-        <h3 class="title">Washington, D.C. Office</h3>
-        <div class="address">
-          154 Russell Senate Office Building<br />
-          Washington, D.C. 20510<br />
-          Phone: (202) 224-2621<br />
-          Fax: (202) 224-0238<br />
-          Toll Free: (866) 481-9186
-        </div>
-      </div>
-      <div class="office" id="office_Everett">
-        <h3 class="title">Everett Office</h3>
-        <div class="address">
-          2930 Wetmore Avenue, Ste. 903<br />
-          Everett, Washington 98201<br />
-          Phone: (425) 259-6515<br />
-          Fax: (425) 259-7152
-        </div>
-      </div>
-      <div class="office" id="office_Vancouver">
-        <h3 class="title">Vancouver Office</h3>
-        <div class="address">
-          The Marshall House<br />
-          1323 Officer's Row<br />
-          Vancouver, Washington 98661<br />
-          Phone: (360) 696-7797<br />
-          Fax: (360) 696-7798
-        </div>
-      </div>
-      <div class="office" id="office_Yakima">
-        <h3 class="title">Yakima Office</h3>
-        <div class="address">
-          402 E. Yakima Ave, Suite 420<br />
-          Yakima, Washington 98901<br />
-          Phone: (509) 453-7462<br />
-          Fax: (509) 453-7731
-        </div>
-      </div>
-      <div class="office" id="office_Seattle">
-        <h3 class="title">Seattle Office</h3>
-        <div class="address">
-          2988 Jackson Federal Building<br />
-          915 2nd Avenue<br />
-          Seattle, Washington 98174<br />
-          Phone: (206) 553-5545<br />
-          Toll Free: (866) 481-9186<br />
-          Fax: (206) 553-0891 
-        </div>
-      </div>
-      <div class="office" id="office_Spokane">
-        <h3 class="title">Spokane Office</h3>
-        <div class="address">
-          10 North Post Street, Suite 600<br />
-          Spokane, Washington 99201<br />
-          Phone: (509) 624-9515<br />
-          Fax: (509) 624-9561 
-        </div>
-      </div>
-      <div class="office" id="office_Tacoma">
-        <h3 class="title">Tacoma Office</h3>
-        <div class="address">
-          950 Pacific Avenue, Ste. 650<br />
-          Tacoma, Washington 98402<br />
-          Phone: (253) 572-3636<br />
-          Fax: (253) 572-9488
-        </div>
-      </div>
-      
-    </div>
-    
-    </div>
-  </div>
+	<div id="sidebarWrapper">
+		<div id="sidebarContent">
+		
+			<div id="subnav">
+				<h2>Related Links</h2>
+				<div id="subnavContent">
+					<div class="subnav subnav_pages subnav_level_12 subnav_child">
+						<ul class="subnav_root">
+						
+						
+							<li class="subnav_item odd first">
+							
+								<a href="https://www.murray.senate.gov/public/index.cfm/newsreleases" class="selected">News Releases</a>
+							
+							</li>
+						
+							<li class="subnav_item even">
+							
+								<a href="https://www.murray.senate.gov/public/index.cfm/pattyinnews" class="">Patty in the News</a>
+							
+							</li>
+						
+							<li class="subnav_item odd">
+							
+								<a href="https://www.murray.senate.gov/public/index.cfm/multimediagallery" class="">Multimedia</a>
+							
+							</li>
+						
+							<li class="subnav_item even last">
+							
+								<a href="https://www.murray.senate.gov/public/index.cfm/blog" class="">Blog</a>
+							
+							</li>
+						
+						</ul>
+					</div>
+				</div>
+			</div>
+		
+		<div id="officeInformation">
+			<h2>Office Information</h2>
+			<div class="office" id="office_DC">
+				<h3 class="title">Washington, D.C. Office</h3>
+				<div class="address">
+					154 Russell Senate Office Building<br />
+					Washington, D.C. 20510<br />
+					Phone: (202) 224-2621<br />
+					Fax: (202) 224-0238<br />
+					Toll Free: (866) 481-9186
+				</div>
+			</div>
+			<div class="office" id="office_Everett">
+				<h3 class="title">Everett Office</h3>
+				<div class="address">
+					2930 Wetmore Avenue, Ste. 9D<br />
+					Everett, Washington 98201<br />
+					Phone: (425) 259-6515<br />
+					Fax: (425) 259-7152
+				</div>
+			</div>
+			<div class="office" id="office_Vancouver">
+				<h3 class="title">Vancouver Office</h3>
+				<div class="address">
+					The Marshall House<br />
+					1323 Officer's Row<br />
+					Vancouver, Washington 98661<br />
+					Phone: (360) 696-7797<br />
+					Fax: (360) 696-7798
+				</div>
+			</div>
+			<div class="office" id="office_Yakima">
+				<h3 class="title">Yakima Office</h3>
+				<div class="address">
+					402 E. Yakima Ave, Suite 420<br />
+					Yakima, Washington 98901<br />
+					Phone: (509) 453-7462<br />
+					Fax: (509) 453-7731
+				</div>
+			</div>
+			<div class="office" id="office_Seattle">
+				<h3 class="title">Seattle Office</h3>
+				<div class="address">
+					2988 Jackson Federal Building<br />
+					915 2nd Avenue<br />
+					Seattle, Washington 98174<br />
+					Phone: (206) 553-5545<br />
+					Toll Free: (866) 481-9186<br />
+					Fax: (206) 553-0891 
+				</div>
+			</div>
+			<div class="office" id="office_Spokane">
+				<h3 class="title">Spokane Office</h3>
+				<div class="address">
+					10 North Post Street, Suite 600<br />
+					Spokane, Washington 99201<br />
+					Phone: (509) 624-9515<br />
+					Fax: (509) 624-9561 
+				</div>
+			</div>
+			<div class="office" id="office_Tacoma">
+				<h3 class="title">Tacoma Office</h3>
+				<div class="address">
+					950 Pacific Avenue, Ste. 650<br />
+					Tacoma, Washington 98402<br />
+					Phone: (253) 572-3636<br />
+					Fax: (253) 572-9488
+				</div>
+			</div>
+			
+		</div>
+		
+		</div>
+	</div>
 </div>
 
 
-      </div>
-    
-      <div class="clear"></div>
-    </div>
-  </div>
+			</div>
+		
+			<div class="clear"></div>
+		</div>
+	</div>
 </div>
 
 
-      </div>
-    </div>
-  </div>
-  
-  <div id="foot">
-    <div class="templateWrapper">
-      <div id="footer">
-        <div id="footerNav">
-            <a href="http://www.murray.senate.gov/public/index.cfm/home">Home</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/aboutpatty">About Patty</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/services">Services</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/newsroom">Newsroom</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/issues">Issues</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/legislation">Legislation</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/sitemap">Site Map</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/contactme">Contact Me</a>
-          | <a href="http://www.murray.senate.gov/public/index.cfm/privacypolicy">Privacy Policy</a>
-        </div>
-        
-        <div class="clear"></div>
-      </div>
-    </div>
-  </div>
+				
+			</div>
+		</div>
+	</div>
+	
+	<div id="foot">
+		<div class="templateWrapper">
+			<div id="footer">
+				<div id="footerNav">
+					  <a href="https://www.murray.senate.gov/public/index.cfm/home">Home</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/aboutpatty">About Patty</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/services">Services</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/newsroom">Newsroom</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/issues">Issues</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/legislation">Legislation</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/sitemap">Site Map</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/contactme">Contact Me</a>
+					| <a href="https://www.murray.senate.gov/public/index.cfm/privacypolicy">Privacy Policy</a>
+				</div>
+				
+				<div class="clear"></div>
+			</div>
+		</div>
+	</div>
 </div>
 
 </div>
@@ -529,8 +555,7 @@ ga('send', 'pageview');
 
 </script>
 
-<script language="JavaScript" type="text/javascript" src="/common/Murray_sen_tag1.js"></script>
-<script language="JavaScript" type="text/javascript" src="/common/sen_tag2.js"></script>
+
 
 <!-- Place this tag in your head or just before your close body tag. -->
 <script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>


### PR DESCRIPTION
#### Improve OutputFormatter.getTextList

Get broader content, more specifically, when text is written directly below a `<div>` element and this element has no child, keep the text (previously it was skipped).

This should help us extract the full content of articles and keeping the paragraphs.