### PR TITLE
Keep Schema.org metadata script tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
     
-    <dependencies>        
+    <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -61,7 +61,7 @@
                 <inherited>true</inherited>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
@@ -78,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.22.1</version>
                 <configuration>
                     <systemProperties>
                         <property>
@@ -87,6 +87,26 @@
                         </property>
                     </systemProperties>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <version>3.0.5</version>
+                            </requireMavenVersion>
+                        </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.10.3</version>
+            <version>1.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
+++ b/src/main/java/de/jetwick/snacktory/ArticleTextExtractor.java
@@ -1229,7 +1229,10 @@ public class ArticleTextExtractor {
     private Document removeScriptsAndStyles(Document doc) {
         Elements scripts = doc.getElementsByTag("script");
         for (Element item : scripts) {
-            item.remove();
+            // Keep schema.org script tag
+            if (! "application/ld+json".equals(item.attr("type"))) {
+                item.remove();
+            }
         }
         Elements noscripts = doc.getElementsByTag("noscript");
         for (Element item : noscripts) {

--- a/src/test/java/de/jetwick/snacktory/HtmlFetcherIntegrationTest.java
+++ b/src/test/java/de/jetwick/snacktory/HtmlFetcherIntegrationTest.java
@@ -30,15 +30,8 @@ public class HtmlFetcherIntegrationTest {
 
     @Test
     public void testNoException() throws Exception {
-        JResult res = new HtmlFetcher().fetchAndExtract("http://www.tumblr.com/xeb22gs619", 10000, true);
-//        System.out.println("tumblr:" + res.getUrl());
-
-//        res = new HtmlFetcher().fetchAndExtract("http://www.faz.net/-01s7fc", 10000, true);
-//        System.out.println("faz:" + res.getUrl());
-
-        res = new HtmlFetcher().fetchAndExtract("http://www.google.com/url?sa=x&q=http://www.taz.de/1/politik/asien/artikel/1/anti-atomkraft-nein-danke/&ct=ga&cad=caeqargbiaaoataaoabaltmh7qrialaawabibwrllurf&cd=d5glzns5m_4&usg=afqjcnetx___sph8sjwhjwi-_mmdnhilra&utm_source=twitterfeed&utm_medium=twitter", 10000, true);
+        JResult res = new HtmlFetcher().fetchAndExtract("http://www.google.com/url?sa=x&q=http://www.taz.de/1/politik/asien/artikel/1/anti-atomkraft-nein-danke/&ct=ga&cad=caeqargbiaaoataaoabaltmh7qrialaawabibwrllurf&cd=d5glzns5m_4&usg=afqjcnetx___sph8sjwhjwi-_mmdnhilra&utm_source=twitterfeed&utm_medium=twitter", 10000, true);
         assertTrue(res.getUrl(), res.getUrl().startsWith("http://www.taz.de/!"));
-//        System.out.println("google redirect:" + res.getUrl());
     }
 
     @Test


### PR DESCRIPTION
When removing all `scripts` tag, make sure that the ones of type `application/json+ld` are retained since they may hold https://schema.org/ metadata information.

This PR also bumps https://jsoup.org/ version to 1.11.3.